### PR TITLE
Optimize Grid layout

### DIFF
--- a/preview/src/App.tsx
+++ b/preview/src/App.tsx
@@ -13,94 +13,15 @@ import { DashboardPanel } from './components/DashboardPanel';
 import { ChartPanel } from './components/ChartPanel';
 import type { PanelConfig, SectionConfig, DashboardConfig } from './types';
 import type { DurationRange } from './constants';
-import { ALL_DATA_SENTINEL, COMMONLY_USED_RANGES, GRID_SETTINGS, DEFAULT_SIZES } from './constants';
+import { ALL_DATA_SENTINEL, COMMONLY_USED_RANGES, GRID_SETTINGS } from './constants';
 import { TimeRangeProvider, useTimeRange } from './context/TimeRangeContext';
 import { useMcpApp } from './context/McpAppContext';
 import { useEsqlQuery } from './hooks/useEsqlQuery';
+import { buildAutoGridLayout } from './utils/auto_layout';
 
 interface OnTimeChangeProps extends DurationRange {
   isInvalid: boolean;
   isQuickSelection: boolean;
-}
-
-function autoPlacePanels(
-  charts: PanelConfig[],
-  startRow: number = 0,
-  columnCount: number = GRID_SETTINGS.columnCount
-): { panels: Record<string, GridPanelData>; nextRow: number } {
-  const panels: Record<string, GridPanelData> = {};
-  let nextRow = startRow;
-  let colOffset = 0;
-  let maxHeightInRow = 0;
-
-  for (const chart of charts) {
-    const size = DEFAULT_SIZES[chart.chartType] || DEFAULT_SIZES.bar;
-    if (colOffset + size.w > columnCount) {
-      nextRow += maxHeightInRow;
-      colOffset = 0;
-      maxHeightInRow = 0;
-    }
-    panels[chart.id] = {
-      id: chart.id,
-      column: colOffset,
-      row: nextRow - startRow,
-      width: size.w,
-      height: size.h,
-    };
-    colOffset += size.w;
-    maxHeightInRow = Math.max(maxHeightInRow, size.h);
-    if (colOffset >= columnCount) {
-      nextRow += maxHeightInRow;
-      colOffset = 0;
-      maxHeightInRow = 0;
-    }
-  }
-  if (colOffset > 0) {
-    nextRow += maxHeightInRow;
-  }
-
-  return { panels, nextRow };
-}
-
-function buildAutoGridLayout(charts: PanelConfig[], sections: SectionConfig[]): GridLayoutData {
-  const layout: GridLayoutData = {};
-  const chartMap = new Map(charts.map((c) => [c.id, c]));
-
-  const assignedPanelIds = new Set<string>();
-  for (const section of sections) {
-    for (const panelId of section.panelIds) {
-      assignedPanelIds.add(panelId);
-    }
-  }
-
-  const unassignedCharts = charts.filter((c) => !assignedPanelIds.has(c.id));
-  const { panels: topLevelPanels, nextRow: afterTopLevel } = autoPlacePanels(unassignedCharts, 0);
-
-  for (const [id, panel] of Object.entries(topLevelPanels)) {
-    layout[id] = { ...panel, type: 'panel' as const };
-  }
-
-  let sectionRow = afterTopLevel;
-  for (const section of sections) {
-    const sectionCharts = section.panelIds
-      .map((id) => chartMap.get(id))
-      .filter((c): c is PanelConfig => c !== undefined);
-
-    const { panels: sectionPanels } = autoPlacePanels(sectionCharts, 0);
-
-    layout[section.id] = {
-      type: 'section' as const,
-      id: section.id,
-      row: sectionRow,
-      title: section.title,
-      isCollapsed: section.collapsed,
-      panels: sectionPanels,
-    };
-
-    sectionRow++;
-  }
-
-  return layout;
 }
 
 function buildGridLayout(

--- a/preview/src/App.tsx
+++ b/preview/src/App.tsx
@@ -1,14 +1,22 @@
 import React, { useCallback, useMemo, useRef, useState } from 'react';
-import { EuiSuperDatePicker, EuiFlexGroup, EuiFlexItem, EuiButtonEmpty } from '@elastic/eui';
+import {
+  EuiSuperDatePicker,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiButtonEmpty,
+  useEuiTheme,
+} from '@elastic/eui';
 import { GridLayout } from './grid-layout';
 import type { GridLayoutData } from './grid-layout';
 import type { GridPanelData } from './grid-layout';
 import { DashboardPanel } from './components/DashboardPanel';
+import { ChartPanel } from './components/ChartPanel';
 import type { PanelConfig, SectionConfig, DashboardConfig } from './types';
 import type { DurationRange } from './constants';
 import { ALL_DATA_SENTINEL, COMMONLY_USED_RANGES, GRID_SETTINGS, DEFAULT_SIZES } from './constants';
 import { TimeRangeProvider, useTimeRange } from './context/TimeRangeContext';
 import { useMcpApp } from './context/McpAppContext';
+import { useEsqlQuery } from './hooks/useEsqlQuery';
 
 interface OnTimeChangeProps extends DurationRange {
   isInvalid: boolean;
@@ -54,7 +62,7 @@ function autoPlacePanels(
   return { panels, nextRow };
 }
 
-function buildGridLayout(charts: PanelConfig[], sections: SectionConfig[]): GridLayoutData {
+function buildAutoGridLayout(charts: PanelConfig[], sections: SectionConfig[]): GridLayoutData {
   const layout: GridLayoutData = {};
   const chartMap = new Map(charts.map((c) => [c.id, c]));
 
@@ -95,10 +103,60 @@ function buildGridLayout(charts: PanelConfig[], sections: SectionConfig[]): Grid
   return layout;
 }
 
-function getDashboardKey(charts: PanelConfig[], sections: SectionConfig[]): string {
+function buildGridLayout(
+  charts: PanelConfig[],
+  sections: SectionConfig[],
+  persistedLayout?: GridLayoutData
+): GridLayoutData {
+  const autoLayout = buildAutoGridLayout(charts, sections);
+  if (!persistedLayout || Object.keys(persistedLayout).length === 0) {
+    return autoLayout;
+  }
+
+  const mergedLayout: GridLayoutData = {};
+  for (const [widgetId, autoWidget] of Object.entries(autoLayout)) {
+    const persistedWidget = persistedLayout[widgetId];
+    if (!persistedWidget || persistedWidget.type !== autoWidget.type) {
+      mergedLayout[widgetId] = autoWidget;
+      continue;
+    }
+
+    if (autoWidget.type === 'panel') {
+      mergedLayout[widgetId] = {
+        ...autoWidget,
+        ...persistedWidget,
+        type: 'panel',
+      };
+      continue;
+    }
+
+    const persistedSection = persistedWidget.type === 'section' ? persistedWidget : undefined;
+    const mergedPanels: Record<string, GridPanelData> = {};
+    for (const [panelId, autoPanel] of Object.entries(autoWidget.panels)) {
+      const persistedPanel = persistedSection?.panels[panelId];
+      mergedPanels[panelId] = persistedPanel ? { ...autoPanel, ...persistedPanel } : autoPanel;
+    }
+
+    mergedLayout[widgetId] = {
+      ...autoWidget,
+      ...persistedSection,
+      type: 'section',
+      panels: mergedPanels,
+    };
+  }
+
+  return mergedLayout;
+}
+
+function getDashboardKey(
+  charts: PanelConfig[],
+  sections: SectionConfig[],
+  gridLayout?: GridLayoutData
+): string {
   const chartsKey = charts.map((c) => `${c.id}:${c.chartType}`).join(',');
   const sectionsKey = sections.map((s) => `${s.id}:${s.panelIds.join('+')}`).join(',');
-  return `${chartsKey}|${sectionsKey}`;
+  const layoutKey = JSON.stringify(gridLayout || {});
+  return `${chartsKey}|${sectionsKey}|${layoutKey}`;
 }
 
 export function App({ initialDashboard }: { initialDashboard: DashboardConfig }) {
@@ -114,6 +172,7 @@ function AppInner({ initialDashboard }: { initialDashboard: DashboardConfig }) {
   const hasCharts = dashboard.charts.length > 0;
   const { setTimeRange } = useTimeRange();
   const mcpApp = useMcpApp();
+  const { euiTheme } = useEuiTheme();
 
   const [isAllData, setIsAllData] = useState(true);
   const [start, setStart] = useState('now-15m');
@@ -134,6 +193,8 @@ function AppInner({ initialDashboard }: { initialDashboard: DashboardConfig }) {
     [setTimeRange]
   );
 
+  const renderChartId = new URLSearchParams(window.location.search).get('render');
+
   const chartMap = useMemo(() => {
     const map: Record<string, PanelConfig> = {};
     for (const chart of dashboard.charts) {
@@ -145,11 +206,11 @@ function AppInner({ initialDashboard }: { initialDashboard: DashboardConfig }) {
   const layoutRef = useRef<GridLayoutData | null>(null);
   const dashboardKeyRef = useRef<string>('');
   const sections = dashboard.sections || [];
-  const currentKey = getDashboardKey(dashboard.charts, sections);
+  const currentKey = getDashboardKey(dashboard.charts, sections, dashboard.gridLayout);
 
   if (currentKey !== dashboardKeyRef.current && hasCharts) {
     dashboardKeyRef.current = currentKey;
-    layoutRef.current = buildGridLayout(dashboard.charts, sections);
+    layoutRef.current = buildGridLayout(dashboard.charts, sections, dashboard.gridLayout);
   }
 
   const handleLayoutChange = useCallback(
@@ -173,24 +234,43 @@ function AppInner({ initialDashboard }: { initialDashboard: DashboardConfig }) {
     [chartMap]
   );
 
+  if (renderChartId) {
+    const chart = dashboard.charts.find((c) => c.id === renderChartId);
+    if (!chart) {
+      return (
+        <div id="render-ready" data-status="not-found">
+          Chart not found
+        </div>
+      );
+    }
+    return <RenderSingleChart config={chart} />;
+  }
+
+  const appStyle: React.CSSProperties = {
+    padding: `${euiTheme.size.l} ${euiTheme.size.xl}`,
+    fontFamily: 'Inter, system-ui, sans-serif',
+    background: 'var(--euiPageBackgroundColor, #101418)',
+    color: 'var(--euiTextColor, #F5F7FA)',
+    minHeight: '100vh',
+  };
+  const subduedTextStyle: React.CSSProperties = {
+    marginTop: euiTheme.size.xs,
+    fontSize: 14,
+    opacity: 0.72,
+  };
+  const emptyStateStyle: React.CSSProperties = {
+    textAlign: 'center',
+    padding: `${euiTheme.size.xxl} ${euiTheme.size.l}`,
+    opacity: 0.8,
+  };
   return (
-    <div
-      style={{
-        padding: '16px 24px',
-        fontFamily: 'Inter, system-ui, sans-serif',
-        background: '#F5F7FA',
-        color: '#343741',
-        minHeight: '100vh',
-      }}
-    >
+    <div style={appStyle}>
       <header style={{ marginBottom: 16 }}>
         <EuiFlexGroup alignItems="center" justifyContent="spaceBetween" responsive={false}>
           <EuiFlexItem grow={false}>
-            <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: '#1A1C21' }}>
-              {dashboard.title}
-            </h1>
+            <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0 }}>{dashboard.title}</h1>
             {hasCharts && (
-              <p style={{ color: '#666', marginTop: 4, fontSize: 14 }}>
+              <p style={subduedTextStyle}>
                 {dashboard.charts.length} chart(s)
                 {sections.length > 0 && ` · ${sections.length} section(s)`}
               </p>
@@ -224,7 +304,7 @@ function AppInner({ initialDashboard }: { initialDashboard: DashboardConfig }) {
           accessMode={'EDIT'}
         />
       ) : (
-        <div style={{ textAlign: 'center', padding: '80px 20px', color: '#666' }}>
+        <div style={emptyStateStyle}>
           <h2 style={{ fontSize: 20, marginBottom: 8 }}>No charts yet</h2>
           <p>
             Use the MCP tools in Cursor to create charts. Try asking:
@@ -236,6 +316,55 @@ function AppInner({ initialDashboard }: { initialDashboard: DashboardConfig }) {
           </p>
         </div>
       )}
+    </div>
+  );
+}
+
+function RenderSingleChart({ config }: { config: PanelConfig }) {
+  const { timeRange } = useTimeRange();
+  const { euiTheme } = useEuiTheme();
+  const { data, isLoading } = useEsqlQuery(config.esqlQuery, timeRange, config.timeField);
+
+  // Fetch trend data for metrics (same logic as DashboardPanel)
+  const trendQuery = config.chartType === 'metric' ? config.trendEsqlQuery : undefined;
+  const { data: trendData, isLoading: trendLoading } = useEsqlQuery(
+    trendQuery,
+    timeRange,
+    config.timeField
+  );
+
+  const liveConfig = useMemo(() => {
+    const base = { ...config, data };
+    if (config.chartType === 'metric' && trendData.length > 0) {
+      return {
+        ...base,
+        trend: {
+          data: trendData.map((row) => ({
+            x: new Date(row[config.trendXField!] as string).getTime(),
+            y: Number(row[config.trendYField!]) || 0,
+          })),
+          shape: config.trendShape || 'area',
+        },
+      };
+    }
+    return base;
+  }, [config, data, trendData]);
+
+  const ready = !isLoading && !trendLoading;
+
+  return (
+    <div
+      id="render-ready"
+      data-status={ready ? 'ok' : 'loading'}
+      style={{
+        width: 600,
+        height: config.chartType === 'metric' ? 200 : 350,
+        padding: Number.parseInt(euiTheme.size.l, 10) || 16,
+        background: 'var(--euiColorEmptyShade, #1D1E24)',
+        color: 'var(--euiTextColor, #F5F7FA)',
+      }}
+    >
+      <ChartPanel config={liveConfig} />
     </div>
   );
 }

--- a/preview/src/components/ChartPanel.test.tsx
+++ b/preview/src/components/ChartPanel.test.tsx
@@ -31,6 +31,13 @@ vi.mock('@elastic/eui', () => ({
     '#FDA49C',
     '#F6726A',
   ],
+  useEuiTheme: () => ({
+    euiTheme: {
+      border: {
+        color: '#2F3D4C',
+      },
+    },
+  }),
 }));
 
 import { ChartPanel } from './ChartPanel';

--- a/preview/src/components/ChartPanel.tsx
+++ b/preview/src/components/ChartPanel.tsx
@@ -14,9 +14,9 @@ import {
   Position,
   ScaleType,
 } from '@elastic/charts';
-import type { MetricDatum, HeatmapBandsColorScale } from '@elastic/charts';
-import { euiPaletteForTemperature } from '@elastic/eui';
-import { ELASTIC_CHARTS_THEME, KIBANA_PALETTE } from '../theme';
+import type { MetricDatum, HeatmapBandsColorScale, PartialTheme } from '@elastic/charts';
+import { euiPaletteForTemperature, useEuiTheme } from '@elastic/eui';
+import { getElasticChartsTheme, KIBANA_PALETTE } from '../theme';
 import type {
   RenderablePanelConfig,
   XYChartPanelConfig,
@@ -42,18 +42,30 @@ function formatDateTime(d: Date): string {
 // ── Router ──
 
 export function ChartPanel({ config }: { config: RenderablePanelConfig }) {
+  const { euiTheme } = useEuiTheme();
+  const chartTheme = useMemo(
+    () => getElasticChartsTheme(euiTheme.border.color),
+    [euiTheme.border.color]
+  );
+
   if (config.chartType === 'metric') {
-    return <MetricPanel config={config as MetricPanelConfig} />;
+    return <MetricPanel config={config as MetricPanelConfig} chartTheme={chartTheme} />;
   }
   if (config.chartType === 'heatmap') {
-    return <HeatmapPanel config={config as HeatmapPanelConfig} />;
+    return <HeatmapPanel config={config as HeatmapPanelConfig} chartTheme={chartTheme} />;
   }
-  return <XYChartPanel config={config as XYChartPanelConfig} />;
+  return <XYChartPanel config={config as XYChartPanelConfig} chartTheme={chartTheme} />;
 }
 
 // ── Metric ──
 
-function MetricPanel({ config }: { config: MetricPanelConfig }) {
+function MetricPanel({
+  config,
+  chartTheme,
+}: {
+  config: MetricPanelConfig;
+  chartTheme: PartialTheme;
+}) {
   const { id, title, subtitle, color, valueField, valuePrefix, valueSuffix, data, trend } = config;
 
   // Derive value from query data using valueField
@@ -79,7 +91,7 @@ function MetricPanel({ config }: { config: MetricPanelConfig }) {
   return (
     <div style={{ height: '100%' }}>
       <Chart>
-        <Settings theme={ELASTIC_CHARTS_THEME} />
+        <Settings theme={chartTheme} />
         <Metric id={id} data={[[metricDatum]]} />
       </Chart>
     </div>
@@ -113,7 +125,13 @@ function buildColorScale(
   return { type: 'bands', bands };
 }
 
-function HeatmapPanel({ config }: { config: HeatmapPanelConfig }) {
+function HeatmapPanel({
+  config,
+  chartTheme,
+}: {
+  config: HeatmapPanelConfig;
+  chartTheme: PartialTheme;
+}) {
   const { id, data = [], xField, yField, valueField, colorRamp } = config;
 
   const colorScale = useMemo(() => {
@@ -121,26 +139,12 @@ function HeatmapPanel({ config }: { config: HeatmapPanelConfig }) {
     return buildColorScale(values, 8, colorRamp);
   }, [data, valueField, colorRamp]);
 
-  if (data.length === 0) return <p>No data</p>;
+  if (data.length === 0) return <p style={{ color: 'inherit' }}>No data</p>;
 
   return (
     <div style={{ height: '100%' }}>
       <Chart>
-        <Settings
-          theme={{
-            ...ELASTIC_CHARTS_THEME,
-            heatmap: {
-              grid: {
-                stroke: { width: 1, color: '#EDF0F5' },
-              },
-              cell: {
-                border: { stroke: '#EDF0F5', strokeWidth: 1 },
-              },
-            },
-          }}
-          showLegend
-          legendPosition={Position.Bottom}
-        />
+        <Settings theme={chartTheme} showLegend legendPosition={Position.Bottom} />
         <Heatmap
           id={id}
           data={data}
@@ -177,11 +181,17 @@ function isLikelyTimeValue(value: unknown): boolean {
   return !Number.isNaN(t);
 }
 
-function XYChartPanel({ config }: { config: XYChartPanelConfig }) {
+function XYChartPanel({
+  config,
+  chartTheme,
+}: {
+  config: XYChartPanelConfig;
+  chartTheme: PartialTheme;
+}) {
   const { id, chartType, data = [], xField, yFields, splitField, palette } = config;
   const colors = palette || KIBANA_PALETTE;
 
-  if (data.length === 0) return <p>No data</p>;
+  if (data.length === 0) return <p style={{ color: 'inherit' }}>No data</p>;
 
   const firstXValue = data[0]?.[xField];
   const isTimeBased = isLikelyTimeValue(firstXValue);
@@ -195,7 +205,7 @@ function XYChartPanel({ config }: { config: XYChartPanelConfig }) {
     <div style={{ height: '100%' }}>
       <Chart>
         <Settings
-          theme={ELASTIC_CHARTS_THEME}
+          theme={chartTheme}
           showLegend={chartType === 'pie' || !!splitField || yFields.length > 1}
           legendPosition={Position.Bottom}
         />

--- a/preview/src/components/DashboardPanel.tsx
+++ b/preview/src/components/DashboardPanel.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { EuiCallOut } from '@elastic/eui';
 import { PanelChrome } from './PanelChrome';
 import { ChartPanel } from './ChartPanel';
 import { useEsqlQuery } from '../hooks/useEsqlQuery';
@@ -33,9 +34,9 @@ export function DashboardPanel({ config }: { config: PanelConfig }) {
   return (
     <PanelChrome title={config.title} isLoading={isLoading}>
       {error ? (
-        <div style={{ padding: 12, color: '#BD271E', fontSize: 13 }}>
-          <strong>Query error:</strong> {error}
-        </div>
+        <EuiCallOut color="danger" iconType="warning" size="s" title="Query error">
+          <p>{error}</p>
+        </EuiCallOut>
       ) : (
         <ChartPanel config={liveConfig} />
       )}

--- a/preview/src/components/PanelChrome.tsx
+++ b/preview/src/components/PanelChrome.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { EuiProgress } from '@elastic/eui';
+import React, { useMemo } from 'react';
+import { EuiPanel, EuiProgress, EuiTitle, useEuiTheme } from '@elastic/eui';
 
 interface PanelChromeProps {
   title: string;
@@ -8,47 +8,54 @@ interface PanelChromeProps {
 }
 
 export function PanelChrome({ title, isLoading, children }: PanelChromeProps) {
+  const { euiTheme } = useEuiTheme();
+  const containerStyle = useMemo<React.CSSProperties>(
+    () => ({
+      position: 'relative',
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100%',
+      overflow: 'hidden',
+    }),
+    []
+  );
+  const headerStyle = useMemo<React.CSSProperties>(
+    () => ({
+      padding: `${euiTheme.size.xs} ${euiTheme.size.m}`,
+      borderBottom: `1px solid ${euiTheme.border.color}`,
+      minHeight: 32,
+      display: 'flex',
+      alignItems: 'center',
+    }),
+    [euiTheme.border.color, euiTheme.size.m, euiTheme.size.xs]
+  );
+  const titleStyle = useMemo<React.CSSProperties>(
+    () => ({
+      margin: 0,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    }),
+    []
+  );
+  const contentStyle = useMemo<React.CSSProperties>(
+    () => ({
+      flex: 1,
+      padding: Number.parseInt(euiTheme.size.s, 10) || 8,
+      minHeight: 0,
+    }),
+    [euiTheme.size.s]
+  );
+
   return (
-    <div style={containerStyle}>
+    <EuiPanel hasBorder hasShadow={false} paddingSize="none" style={containerStyle}>
       {isLoading && <EuiProgress size="xs" color="accent" position="absolute" />}
       <div style={headerStyle}>
-        <span style={titleStyle}>{title}</span>
+        <EuiTitle size="xxxs">
+          <h3 style={titleStyle}>{title}</h3>
+        </EuiTitle>
       </div>
       <div style={contentStyle}>{children}</div>
-    </div>
+    </EuiPanel>
   );
 }
-
-const containerStyle: React.CSSProperties = {
-  position: 'relative',
-  display: 'flex',
-  flexDirection: 'column',
-  height: '100%',
-  border: '1px solid #D3DAE6',
-  borderRadius: 6,
-  background: '#fff',
-  overflow: 'hidden',
-};
-
-const headerStyle: React.CSSProperties = {
-  padding: '6px 12px',
-  borderBottom: '1px solid #EEF0F4',
-  minHeight: 32,
-  display: 'flex',
-  alignItems: 'center',
-};
-
-const titleStyle: React.CSSProperties = {
-  fontSize: 14,
-  fontWeight: 600,
-  color: '#343741',
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
-  whiteSpace: 'nowrap',
-};
-
-const contentStyle: React.CSSProperties = {
-  flex: 1,
-  padding: 8,
-  minHeight: 0,
-};

--- a/preview/src/main.tsx
+++ b/preview/src/main.tsx
@@ -7,7 +7,7 @@ import { ChartPreview } from './components/ChartPreview';
 import { McpAppProvider } from './context/McpAppContext';
 import type { DashboardConfig, PanelConfig } from './types';
 
-import '@elastic/charts/dist/theme_light.css';
+import '@elastic/charts/dist/theme_dark.css';
 
 // Pre-cache icons used by kbn-grid-layout and EuiSuperDatePicker
 import { appendIconComponentCache } from '@elastic/eui/es/components/icon/icon';
@@ -141,10 +141,8 @@ function Root() {
     mcpApp.connect();
   }, [mcpApp]);
 
-  // Enforce light theme for now
-  // TODO set up proper dark/light theme support for charts and EUI components
   return (
-    <EuiProvider colorMode="light">
+    <EuiProvider colorMode="dark">
       <RootContent
         viewMode={viewMode}
         chartPreview={chartPreview}
@@ -179,7 +177,7 @@ function RootContent({
   }
 
   return (
-    <div style={{ padding: 40, textAlign: 'center', color: '#666' }}>
+    <div style={{ padding: 40, textAlign: 'center', color: 'inherit' }}>
       {viewMode ? 'Loading…' : 'Waiting for data…'}
     </div>
   );

--- a/preview/src/theme.ts
+++ b/preview/src/theme.ts
@@ -3,12 +3,22 @@ import { euiPaletteColorBlind } from '@elastic/eui';
 
 export const KIBANA_PALETTE: string[] = euiPaletteColorBlind();
 
-export const ELASTIC_CHARTS_THEME: PartialTheme = {
-  background: {
-    color: 'transparent',
-  },
-  colors: {
-    vizColors: KIBANA_PALETTE,
-    defaultVizColor: KIBANA_PALETTE[0],
-  },
-};
+export function getElasticChartsTheme(heatmapBorderColor: string): PartialTheme {
+  return {
+    background: {
+      color: 'transparent',
+    },
+    colors: {
+      vizColors: KIBANA_PALETTE,
+      defaultVizColor: KIBANA_PALETTE[0],
+    },
+    heatmap: {
+      grid: {
+        stroke: { width: 1, color: heatmapBorderColor },
+      },
+      cell: {
+        border: { stroke: heatmapBorderColor, strokeWidth: 1 },
+      },
+    },
+  };
+}

--- a/preview/src/types.ts
+++ b/preview/src/types.ts
@@ -1,3 +1,5 @@
+import type { GridLayoutData } from './grid-layout';
+
 export interface ChartConfig {
   id: string;
   title: string;
@@ -52,6 +54,7 @@ export interface DashboardConfig {
   title: string;
   charts: PanelConfig[];
   sections: SectionConfig[];
+  gridLayout?: GridLayoutData;
   updatedAt: string;
 }
 

--- a/preview/src/utils/auto_layout.test.ts
+++ b/preview/src/utils/auto_layout.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import type { ChartConfig, MetricConfig, SectionConfig } from '../types';
+import { autoPlacePanels, buildAutoGridLayout } from './auto_layout';
+
+function makeBarChart(id: string): ChartConfig {
+  return {
+    id,
+    title: `Bar ${id}`,
+    chartType: 'bar',
+    esqlQuery: 'FROM ecommerce | STATS revenue = SUM(price) BY category',
+    xField: 'category',
+    yFields: ['revenue'],
+  };
+}
+
+function makeMetric(id: string): MetricConfig {
+  return {
+    id,
+    title: `Metric ${id}`,
+    chartType: 'metric',
+    valueField: 'total',
+    esqlQuery: 'FROM ecommerce | STATS total = COUNT(*)',
+  };
+}
+
+describe('autoPlacePanels', () => {
+  it('makes a single chart span the full row', () => {
+    const { panels, nextRow } = autoPlacePanels([makeBarChart('bar-1')]);
+
+    expect(panels['bar-1']).toMatchObject({
+      column: 0,
+      row: 0,
+      width: 48,
+      height: 15,
+    });
+    expect(nextRow).toBe(15);
+  });
+
+  it('splits two charts evenly across the row', () => {
+    const { panels } = autoPlacePanels([makeBarChart('bar-1'), makeMetric('metric-1')]);
+
+    expect(panels['bar-1']).toMatchObject({ column: 0, row: 0, width: 24, height: 15 });
+    expect(panels['metric-1']).toMatchObject({ column: 24, row: 0, width: 24, height: 10 });
+  });
+
+  it('splits three charts evenly while preserving heights', () => {
+    const { panels, nextRow } = autoPlacePanels([
+      makeBarChart('bar-1'),
+      makeMetric('metric-1'),
+      makeMetric('metric-2'),
+    ]);
+
+    expect(panels['bar-1']).toMatchObject({ column: 0, row: 0, width: 16, height: 15 });
+    expect(panels['metric-1']).toMatchObject({ column: 16, row: 0, width: 16, height: 10 });
+    expect(panels['metric-2']).toMatchObject({ column: 32, row: 0, width: 16, height: 10 });
+    expect(nextRow).toBe(15);
+  });
+});
+
+describe('buildAutoGridLayout', () => {
+  it('balances section panels independently of top-level panels', () => {
+    const section: SectionConfig = {
+      id: 'sec-1',
+      title: 'KPIs',
+      collapsed: false,
+      panelIds: ['metric-1', 'metric-2'],
+    };
+
+    const layout = buildAutoGridLayout(
+      [makeBarChart('bar-1'), makeMetric('metric-1'), makeMetric('metric-2')],
+      [section]
+    );
+
+    expect(layout['bar-1']).toMatchObject({
+      type: 'panel',
+      column: 0,
+      row: 0,
+      width: 48,
+      height: 15,
+    });
+    expect(layout['sec-1']).toMatchObject({
+      type: 'section',
+      row: 15,
+      title: 'KPIs',
+    });
+    const sectionLayout = layout['sec-1'];
+    expect(sectionLayout.type).toBe('section');
+    if (sectionLayout.type !== 'section') {
+      throw new Error('Expected a section layout');
+    }
+
+    expect(sectionLayout.panels['metric-1']).toMatchObject({
+      column: 0,
+      row: 0,
+      width: 24,
+      height: 10,
+    });
+    expect(sectionLayout.panels['metric-2']).toMatchObject({
+      column: 24,
+      row: 0,
+      width: 24,
+      height: 10,
+    });
+  });
+});

--- a/preview/src/utils/auto_layout.ts
+++ b/preview/src/utils/auto_layout.ts
@@ -1,0 +1,120 @@
+import type { GridLayoutData, GridPanelData } from '../grid-layout';
+import { DEFAULT_SIZES, GRID_SETTINGS } from '../constants';
+import type { PanelConfig, SectionConfig } from '../types';
+
+interface RowPanel {
+  chart: PanelConfig;
+  height: number;
+}
+
+function finalizeRow(
+  rowPanels: RowPanel[],
+  row: number,
+  panels: Record<string, GridPanelData>,
+  columnCount: number
+): number {
+  if (rowPanels.length === 0) {
+    return 0;
+  }
+
+  const baseWidth = Math.floor(columnCount / rowPanels.length);
+  const remainder = columnCount % rowPanels.length;
+  let column = 0;
+  let maxHeightInRow = 0;
+
+  for (const [index, rowPanel] of rowPanels.entries()) {
+    const width = baseWidth + (index < remainder ? 1 : 0);
+    panels[rowPanel.chart.id] = {
+      id: rowPanel.chart.id,
+      column,
+      row,
+      width,
+      height: rowPanel.height,
+    };
+    column += width;
+    maxHeightInRow = Math.max(maxHeightInRow, rowPanel.height);
+  }
+
+  return maxHeightInRow;
+}
+
+export function autoPlacePanels(
+  charts: PanelConfig[],
+  startRow: number = 0,
+  columnCount: number = GRID_SETTINGS.columnCount
+): { panels: Record<string, GridPanelData>; nextRow: number } {
+  const panels: Record<string, GridPanelData> = {};
+  let nextRow = startRow;
+  let rowPanels: RowPanel[] = [];
+  let widthInRow = 0;
+
+  const flushRow = () => {
+    const maxHeightInRow = finalizeRow(rowPanels, nextRow - startRow, panels, columnCount);
+    if (maxHeightInRow > 0) {
+      nextRow += maxHeightInRow;
+    }
+    rowPanels = [];
+    widthInRow = 0;
+  };
+
+  for (const chart of charts) {
+    const size = DEFAULT_SIZES[chart.chartType] || DEFAULT_SIZES.bar;
+    if (rowPanels.length > 0 && widthInRow + size.w > columnCount) {
+      flushRow();
+    }
+
+    rowPanels.push({ chart, height: size.h });
+    widthInRow += size.w;
+
+    if (widthInRow >= columnCount) {
+      flushRow();
+    }
+  }
+
+  flushRow();
+  return { panels, nextRow };
+}
+
+export function buildAutoGridLayout(
+  charts: PanelConfig[],
+  sections: SectionConfig[]
+): GridLayoutData {
+  const layout: GridLayoutData = {};
+  const chartMap = new Map(charts.map((chart) => [chart.id, chart]));
+
+  const assignedPanelIds = new Set<string>();
+  for (const section of sections) {
+    for (const panelId of section.panelIds) {
+      assignedPanelIds.add(panelId);
+    }
+  }
+
+  const unassignedCharts = charts.filter((chart) => !assignedPanelIds.has(chart.id));
+  const { panels: topLevelPanels, nextRow: afterTopLevel } = autoPlacePanels(unassignedCharts, 0);
+
+  for (const [id, panel] of Object.entries(topLevelPanels)) {
+    layout[id] = { ...panel, type: 'panel' as const };
+  }
+
+  let sectionRow = afterTopLevel;
+  for (const section of sections) {
+    const sectionCharts = section.panelIds
+      .map((id) => chartMap.get(id))
+      .filter((chart): chart is PanelConfig => chart !== undefined);
+
+    const { panels: sectionPanels } = autoPlacePanels(sectionCharts, 0);
+
+    layout[section.id] = {
+      type: 'section' as const,
+      id: section.id,
+      row: sectionRow,
+      title: section.title,
+      isCollapsed: section.collapsed,
+      panels: sectionPanels,
+    };
+
+    sectionRow++;
+  }
+
+  return layout;
+}

--- a/server/src/utils/dashboard-translator.test.ts
+++ b/server/src/utils/dashboard-translator.test.ts
@@ -29,6 +29,14 @@ const metric: MetricConfig = {
   esqlQuery: 'FROM ecommerce | STATS total = COUNT(*)',
 };
 
+function makeMetric(id: string): MetricConfig {
+  return {
+    ...metric,
+    id,
+    title: `Metric ${id}`,
+  };
+}
+
 describe('translateDashboardToSavedObject', () => {
   it('produces valid attributes with title and panelsJSON', () => {
     const config = makeDashboard({ charts: [barChart] });
@@ -40,19 +48,26 @@ describe('translateDashboardToSavedObject', () => {
     const panels = JSON.parse(attributes.panelsJSON as string);
     expect(panels).toHaveLength(1);
     expect(panels[0].type).toBe('lens');
+    expect(panels[0].gridData).toMatchObject({ x: 0, y: 0, w: 48, h: 15 });
   });
 
-  it('auto-places panels with correct grid positions', () => {
+  it('evenly distributes two charts across the row', () => {
     const config = makeDashboard({ charts: [barChart, metric] });
     const { attributes } = translateDashboardToSavedObject(config);
     const panels = JSON.parse(attributes.panelsJSON as string);
 
-    // First panel at x=0
-    expect(panels[0].gridData.x).toBe(0);
-    expect(panels[0].gridData.y).toBe(0);
+    expect(panels[0].gridData).toMatchObject({ x: 0, y: 0, w: 24, h: 15 });
+    expect(panels[1].gridData).toMatchObject({ x: 24, y: 0, w: 24, h: 10 });
+  });
 
-    // Second panel also at y=0 (fits beside bar chart since metric is narrow)
-    expect(panels[1].gridData.x).toBeGreaterThan(0);
+  it('evenly distributes three charts in the same row while preserving heights', () => {
+    const config = makeDashboard({ charts: [barChart, metric, makeMetric('metric-2')] });
+    const { attributes } = translateDashboardToSavedObject(config);
+    const panels = JSON.parse(attributes.panelsJSON as string);
+
+    expect(panels[0].gridData).toMatchObject({ x: 0, y: 0, w: 16, h: 15 });
+    expect(panels[1].gridData).toMatchObject({ x: 16, y: 0, w: 16, h: 10 });
+    expect(panels[2].gridData).toMatchObject({ x: 32, y: 0, w: 16, h: 10 });
   });
 
   it('uses gridLayout positions when provided', () => {
@@ -71,16 +86,43 @@ describe('translateDashboardToSavedObject', () => {
     expect(panels[0].gridData.h).toBe(20);
   });
 
-  it('includes sections', () => {
+  it('balances section panels using the same row logic', () => {
     const config = makeDashboard({
-      charts: [barChart],
-      sections: [{ id: 'sec-1', title: 'Revenue Section', collapsed: false, panelIds: ['bar-1'] }],
+      charts: [barChart, metric, makeMetric('metric-2')],
+      sections: [
+        {
+          id: 'sec-1',
+          title: 'Revenue Section',
+          collapsed: false,
+          panelIds: ['metric-1', 'metric-2'],
+        },
+      ],
     });
     const { attributes } = translateDashboardToSavedObject(config);
+    const panels = JSON.parse(attributes.panelsJSON as string);
+    const sectionPanels = panels.filter(
+      (panel: { gridData: { sectionId?: string } }) => panel.gridData.sectionId === 'sec-1'
+    );
 
     expect(attributes.sections).toBeDefined();
-    const sections = attributes.sections as Array<{ title: string }>;
+    const sections = attributes.sections as Array<{ title: string; gridData: { y: number } }>;
     expect(sections[0].title).toBe('Revenue Section');
+    expect(sections[0].gridData.y).toBe(15);
+    expect(sectionPanels).toHaveLength(2);
+    expect(sectionPanels[0].gridData).toMatchObject({
+      x: 0,
+      y: 0,
+      w: 24,
+      h: 10,
+      sectionId: 'sec-1',
+    });
+    expect(sectionPanels[1].gridData).toMatchObject({
+      x: 24,
+      y: 0,
+      w: 24,
+      h: 10,
+      sectionId: 'sec-1',
+    });
   });
 
   it('embeds Lens attributes in each panel', () => {

--- a/server/src/utils/dashboard-translator.ts
+++ b/server/src/utils/dashboard-translator.ts
@@ -9,6 +9,7 @@ const THREE_QUARTER_WIDTH = 36;
 const QUARTER_WIDTH = 12;
 const DEFAULT_HEIGHT = 15;
 const METRIC_HEIGHT = 10;
+const GRID_COLUMN_COUNT = 48;
 
 const DEFAULT_SIZES: Record<string, { w: number; h: number }> = {
   bar: { w: HALF_WIDTH, h: DEFAULT_HEIGHT },
@@ -24,6 +25,11 @@ interface SavedDashboardPanel {
   type: string;
   gridData: { x: number; y: number; w: number; h: number; i: string; sectionId?: string };
   embeddableConfig: Record<string, unknown>;
+}
+
+interface RowPanel {
+  chart: PanelConfig;
+  height: number;
 }
 
 function buildSavedPanel(
@@ -47,6 +53,44 @@ function buildSavedPanel(
   };
 }
 
+function buildBalancedRowWidths(panelCount: number, columnCount: number): number[] {
+  const baseWidth = Math.floor(columnCount / panelCount);
+  const remainder = columnCount % panelCount;
+
+  return Array.from({ length: panelCount }, (_, index) => baseWidth + (index < remainder ? 1 : 0));
+}
+
+function flushRow(
+  rowPanels: RowPanel[],
+  nextRow: number,
+  panels: SavedDashboardPanel[],
+  sectionId: string | undefined,
+  ctxFn?: (chart: PanelConfig) => TimeFieldContext | undefined
+): number {
+  if (rowPanels.length === 0) {
+    return 0;
+  }
+
+  const widths = buildBalancedRowWidths(rowPanels.length, GRID_COLUMN_COUNT);
+  let column = 0;
+  let maxHeightInRow = 0;
+
+  for (const [index, rowPanel] of rowPanels.entries()) {
+    panels.push(
+      buildSavedPanel(
+        rowPanel.chart,
+        { x: column, y: nextRow, w: widths[index], h: rowPanel.height },
+        sectionId,
+        ctxFn?.(rowPanel.chart)
+      )
+    );
+    column += widths[index];
+    maxHeightInRow = Math.max(maxHeightInRow, rowPanel.height);
+  }
+
+  return maxHeightInRow;
+}
+
 /**
  * Auto-place panels in a flowing layout (fallback when no grid positions stored).
  */
@@ -58,33 +102,33 @@ function autoPlacePanels(
 ): { panels: SavedDashboardPanel[]; nextRow: number } {
   const panels: SavedDashboardPanel[] = [];
   let nextRow = startRow;
-  let colOffset = 0;
-  let maxHeightInRow = 0;
+  let rowPanels: RowPanel[] = [];
+  let widthInRow = 0;
+
+  const commitRow = () => {
+    const maxHeightInRow = flushRow(rowPanels, nextRow, panels, sectionId, ctxFn);
+    if (maxHeightInRow > 0) {
+      nextRow += maxHeightInRow;
+    }
+    rowPanels = [];
+    widthInRow = 0;
+  };
 
   for (const chart of charts) {
     const size = DEFAULT_SIZES[chart.chartType] || DEFAULT_SIZES.bar;
-    if (colOffset + size.w > 48) {
-      nextRow += maxHeightInRow;
-      colOffset = 0;
-      maxHeightInRow = 0;
+    if (rowPanels.length > 0 && widthInRow + size.w > GRID_COLUMN_COUNT) {
+      commitRow();
     }
-    panels.push(
-      buildSavedPanel(
-        chart,
-        { x: colOffset, y: nextRow, w: size.w, h: size.h },
-        sectionId,
-        ctxFn?.(chart)
-      )
-    );
-    colOffset += size.w;
-    maxHeightInRow = Math.max(maxHeightInRow, size.h);
-    if (colOffset >= 48) {
-      nextRow += maxHeightInRow;
-      colOffset = 0;
-      maxHeightInRow = 0;
+
+    rowPanels.push({ chart, height: size.h });
+    widthInRow += size.w;
+
+    if (widthInRow >= GRID_COLUMN_COUNT) {
+      commitRow();
     }
   }
-  if (colOffset > 0) nextRow += maxHeightInRow;
+
+  commitRow();
   return { panels, nextRow };
 }
 


### PR DESCRIPTION
Adds a step after chart generation to optimize charts to use the full width available to them in their row.

<img width="582" height="523" alt="Screenshot 2026-04-09 at 5 03 16 PM" src="https://github.com/user-attachments/assets/6313cbe1-e418-4754-98e1-ce8c2166fb03" />
<img width="582" height="523" alt="Screenshot 2026-04-09 at 5 03 16 PM" src="https://github.com/user-attachments/assets/6313cbe1-e418-4754-98e1-ce8c2166fb03" />
