### PR TITLE
Session isolation

### DIFF
--- a/ONE_PAGER.md
+++ b/ONE_PAGER.md
@@ -126,22 +126,16 @@ The grid layout is currently vendored (copy-pasted) from the Kibana repository. 
 - Versioned and maintained alongside Kibana releases
 - Installed via `npm install` instead of copied into the project
 
-**5. Resolve licensing for vendored code**
-The grid layout code carries Elastic License 2.0 + SSPL headers from Kibana. Publishing as a separate npm package with clear licensing is required.
-
-**6. Align visualization capabilities with Lens**
+**5. Align visualization capabilities with Lens**
 Currently the app can create Elastic Charts configurations that have no equivalent in Lens. The AI should be instructed with Lens-specific constraints so that every chart it creates can be faithfully exported to Kibana. The dataviz guidelines resource should document what Lens supports and what it doesn't.
 
-**7. Support more Lens chart types**
+**6. Support more Lens chart types**
 Only bar, line, area, pie, metric, and heatmap are supported today. Lens also supports gauge, donut, treemap/mosaic, datatable, and tag cloud. Adding these would increase the coverage of dashboards that can be round-tripped between the MCP app and Kibana.
 
-**8. Error UX in the preview**
+**7. Error UX in the preview**
 When an ES|QL query fails, panels show a basic error message. The preview should display more detailed error information to help users debug query issues.
 
 ### Nice to Have
-
-**9. Session isolation**
-The MCP server stores dashboard state in memory per process. All chat sessions within one host window share the same state. Introducing session scoping or per-chat namespacing would allow parallel dashboard work.
 
 **10. Collaborative editing**
 Multiple users working on the same dashboard via shared MCP server state.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ One-click export to Kibana as Lens visualizations
 - **Custom color themes** — apply custom palettes to charts, heatmaps, and metrics
 - **Time picker** — filter data by time range with automatic time field detection
 - **Multiple dashboards** — create, switch between, and manage multiple dashboards
+- **Session isolation** — parallel chat conversations work on separate dashboards via `dashboardId` threading
 - **Elastic Cloud support** — works with local Elasticsearch and Elastic Cloud (Cloud ID + API key)
 - **Server instructions** — workflow, tips, and capabilities exposed to every MCP client via the `initialize` response
 - **Dataviz best practices** — built-in guidelines for chart selection and dashboard composition

--- a/package-lock.json
+++ b/package-lock.json
@@ -9445,6 +9445,7 @@
     "preview": {
       "name": "mcp-dashboards-preview",
       "version": "0.1.0",
+      "license": "Elastic-2.0",
       "dependencies": {
         "@elastic/charts": "^71.4.1",
         "@elastic/esql": "^1.6.0",
@@ -9476,6 +9477,7 @@
     "server": {
       "name": "mcp-dashboards-server",
       "version": "0.1.0",
+      "license": "Elastic-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^9.0.0",
         "@elastic/esql": "^1.7.0",

--- a/preview/src/main.tsx
+++ b/preview/src/main.tsx
@@ -177,8 +177,14 @@ function Root() {
             }
           });
       } else {
+        // Pass dashboardId from the tool arguments so the MCP App shows
+        // the correct dashboard for this conversation's session.
+        const dashboardId = toolInputRef.current?.dashboardId as string | undefined;
         mcpApp
-          .callServerTool({ name: 'app_only_get_dashboard_config', arguments: {} })
+          .callServerTool({
+            name: 'app_only_get_dashboard_config',
+            arguments: dashboardId ? { dashboardId } : {},
+          })
           .then((r) => {
             const data = parseToolResult(r) as DashboardConfig | null;
             if (data) {

--- a/server/src/resources/instructions.ts
+++ b/server/src/resources/instructions.ts
@@ -15,13 +15,15 @@ Elasticsearch visualizations using ES|QL and Elastic Charts.
 ## Workflow
 
 1. Read the \`dataviz://guidelines\` and \`esql://reference\` resources before creating charts.
-2. Create a new dashboard with \`create_dashboard\` (or use the active one).
-3. Use \`list_indices\` and \`get_fields\` to explore available data.
-4. Use \`run_esql\` to test queries before creating charts.
-5. Create visualizations with \`create_chart\`, \`create_metric\`, \`create_heatmap\`.
-6. Organize with \`create_section\` and \`move_panel_to_section\`.
-7. Call \`view_dashboard\` to show the interactive preview.
-8. Export with \`export_to_kibana\` when ready.
+2. Create a new dashboard with \`create_dashboard\` — note the returned \`dashboardId\`.
+3. **Pass \`dashboardId\` on every subsequent tool call** in this conversation to ensure \
+session isolation. This prevents different chat sessions from interfering with each other.
+4. Use \`list_indices\` and \`get_fields\` to explore available data.
+5. Use \`run_esql\` to test queries before creating charts.
+6. Create visualizations with \`create_chart\`, \`create_metric\`, \`create_heatmap\`.
+7. Organize with \`create_section\` and \`move_panel_to_section\`.
+8. Call \`view_dashboard\` to show the interactive preview.
+9. Export with \`export_to_kibana\` when ready.
 
 ## Tips
 

--- a/server/src/tools/app-only-tools.ts
+++ b/server/src/tools/app-only-tools.ts
@@ -30,12 +30,17 @@ export function registerAppOnlyTools(server: McpServer): void {
     {
       title: 'Get Dashboard Config',
       description:
-        'Returns the full active dashboard configuration including all charts, sections, and layout.',
-      inputSchema: {},
+        'Returns the full dashboard configuration including all charts, sections, and layout.',
+      inputSchema: {
+        dashboardId: z
+          .string()
+          .optional()
+          .describe('Dashboard ID to retrieve. If omitted, returns the active dashboard.'),
+      },
       _meta: { ui: { visibility: ['app'] } },
     },
-    async () => {
-      const dashboard = getDashboard();
+    async ({ dashboardId }) => {
+      const dashboard = getDashboard(dashboardId);
       return {
         content: [
           {
@@ -122,12 +127,16 @@ export function registerAppOnlyTools(server: McpServer): void {
       description: 'Persist grid layout changes from drag/resize in the dashboard.',
       inputSchema: {
         layout: z.record(z.string(), z.unknown()).describe('Grid layout data from kbn-grid-layout'),
+        dashboardId: z
+          .string()
+          .optional()
+          .describe('Dashboard ID for session isolation. If omitted, uses the active dashboard.'),
       },
       _meta: { ui: { visibility: ['app'] } },
     },
-    async ({ layout }) => {
+    async ({ layout, dashboardId }) => {
       try {
-        saveDashboardLayout(layout as DashboardConfig['gridLayout']);
+        saveDashboardLayout(layout as DashboardConfig['gridLayout'], dashboardId);
         return {
           content: [{ type: 'text' as const, text: 'Layout saved' }],
         };

--- a/server/src/tools/create-chart.ts
+++ b/server/src/tools/create-chart.ts
@@ -61,6 +61,12 @@ export function registerCreateChart(server: McpServer): void {
             'Optional date field for time filtering, e.g. "@timestamp" or "order_date". ' +
               'Set this when the index has multiple date fields to ensure the time picker filters correctly.'
           ),
+        dashboardId: z
+          .string()
+          .optional()
+          .describe(
+            'Target dashboard ID for session isolation. If omitted, uses the active dashboard.'
+          ),
       },
       _meta: {
         ui: { resourceUri: CHART_PREVIEW_RESOURCE_URI },
@@ -117,7 +123,7 @@ export function registerCreateChart(server: McpServer): void {
         timeField,
       };
 
-      const dashboard = addChart(chart);
+      const dashboard = addChart(chart, args.dashboardId);
 
       const statusText =
         `Chart "${title}" (${chartType}) added to dashboard. ` +

--- a/server/src/tools/create-heatmap.ts
+++ b/server/src/tools/create-heatmap.ts
@@ -63,6 +63,12 @@ export function registerCreateHeatmap(server: McpServer): void {
             'Optional date field for time filtering, e.g. "@timestamp". ' +
               'Set this when the index has multiple date fields.'
           ),
+        dashboardId: z
+          .string()
+          .optional()
+          .describe(
+            'Target dashboard ID for session isolation. If omitted, uses the active dashboard.'
+          ),
       },
       _meta: {
         ui: { resourceUri: CHART_PREVIEW_RESOURCE_URI },
@@ -113,7 +119,7 @@ export function registerCreateHeatmap(server: McpServer): void {
         timeField,
       };
 
-      const dashboard = addChart(heatmap);
+      const dashboard = addChart(heatmap, args.dashboardId);
 
       const values = data.map((d) => Number(d[valueField])).filter((v) => !isNaN(v));
       const min = Math.min(...values);

--- a/server/src/tools/create-metric.ts
+++ b/server/src/tools/create-metric.ts
@@ -80,6 +80,12 @@ export function registerCreateMetric(server: McpServer): void {
             'Optional date field for time filtering, e.g. "@timestamp". ' +
               'Set this when the index has multiple date fields.'
           ),
+        dashboardId: z
+          .string()
+          .optional()
+          .describe(
+            'Target dashboard ID for session isolation. If omitted, uses the active dashboard.'
+          ),
       },
       _meta: {
         ui: { resourceUri: CHART_PREVIEW_RESOURCE_URI },
@@ -179,7 +185,7 @@ export function registerCreateMetric(server: McpServer): void {
         timeField,
       };
 
-      const dashboard = addChart(metric);
+      const dashboard = addChart(metric, args.dashboardId);
 
       const formattedValue = `${valuePrefix || ''}${value.toLocaleString()}${valueSuffix || ''}`;
       const statusText =

--- a/server/src/tools/create-section.ts
+++ b/server/src/tools/create-section.ts
@@ -31,17 +31,18 @@ export function registerSectionTools(server: McpServer): void {
           .optional()
           .default([])
           .describe('Optional list of panel IDs to include in this section immediately'),
+        dashboardId: z
+          .string()
+          .optional()
+          .describe(
+            'Target dashboard ID for session isolation. If omitted, uses the active dashboard.'
+          ),
       },
     },
     async (args) => {
       const { id, title, panelIds } = args;
 
-      const dashboard = addSection({
-        id,
-        title,
-        collapsed: false,
-        panelIds,
-      });
+      const dashboard = addSection({ id, title, collapsed: false, panelIds }, args.dashboardId);
 
       return {
         content: [
@@ -64,13 +65,20 @@ export function registerSectionTools(server: McpServer): void {
       inputSchema: {
         panelId: z.string().describe('The ID of the panel to move'),
         sectionId: z.string().describe('The ID of the section to move the panel into'),
+        dashboardId: z
+          .string()
+          .optional()
+          .describe(
+            'Target dashboard ID for session isolation. If omitted, uses the active dashboard.'
+          ),
       },
     },
     async (args) => {
-      const { panelId, sectionId } = args;
-      movePanelToSection(panelId, sectionId);
+      movePanelToSection(args.panelId, args.sectionId, args.dashboardId);
       return {
-        content: [{ type: 'text', text: `Panel "${panelId}" moved to section "${sectionId}".` }],
+        content: [
+          { type: 'text', text: `Panel "${args.panelId}" moved to section "${args.sectionId}".` },
+        ],
       };
     }
   );
@@ -83,13 +91,18 @@ export function registerSectionTools(server: McpServer): void {
       description: 'Remove a section. Panels in the section will become top-level panels again.',
       inputSchema: {
         sectionId: z.string().describe('The ID of the section to remove'),
+        dashboardId: z
+          .string()
+          .optional()
+          .describe(
+            'Target dashboard ID for session isolation. If omitted, uses the active dashboard.'
+          ),
       },
     },
     async (args) => {
-      const { sectionId } = args;
-      removeSection(sectionId);
+      removeSection(args.sectionId, args.dashboardId);
       return {
-        content: [{ type: 'text', text: `Section "${sectionId}" removed.` }],
+        content: [{ type: 'text', text: `Section "${args.sectionId}" removed.` }],
       };
     }
   );

--- a/server/src/tools/export-to-kibana.ts
+++ b/server/src/tools/export-to-kibana.ts
@@ -36,6 +36,12 @@ export function registerExportToKibana(server: McpServer): void {
           .describe(
             'Optional title override for the Kibana dashboard. Defaults to the current dashboard title.'
           ),
+        dashboardId: z
+          .string()
+          .optional()
+          .describe(
+            'Target dashboard ID for session isolation. If omitted, uses the active dashboard.'
+          ),
       },
     },
     async (args) => {
@@ -54,7 +60,7 @@ export function registerExportToKibana(server: McpServer): void {
         };
       }
 
-      const dashboard = getDashboard();
+      const dashboard = getDashboard(args.dashboardId);
 
       if (dashboard.charts.length === 0) {
         return {

--- a/server/src/tools/manage-dashboard.ts
+++ b/server/src/tools/manage-dashboard.ts
@@ -18,6 +18,11 @@ import {
 } from '../utils/dashboard-store.js';
 import { registerTool } from '../utils/register-tool.js';
 
+const dashboardIdParam = z
+  .string()
+  .optional()
+  .describe('Target dashboard ID for session isolation. If omitted, uses the active dashboard.');
+
 export function registerManageDashboard(server: McpServer): void {
   registerTool(
     server,
@@ -26,7 +31,8 @@ export function registerManageDashboard(server: McpServer): void {
       title: 'Create Dashboard',
       description:
         'Create a new empty dashboard and make it the active one. ' +
-        'The previous dashboard is preserved and can be switched back to with switch_dashboard.',
+        'The previous dashboard is preserved and can be switched back to with switch_dashboard. ' +
+        'Returns the new dashboard ID — pass it as dashboardId on subsequent tool calls to maintain session isolation.',
       inputSchema: {
         title: z.string().describe('Dashboard title, e.g. "Ecommerce Overview"'),
         id: z
@@ -41,7 +47,7 @@ export function registerManageDashboard(server: McpServer): void {
         content: [
           {
             type: 'text',
-            text: `Dashboard "${dashboard.title}" created (id: ${dashId}) and set as active.`,
+            text: `Dashboard "${dashboard.title}" created (id: ${dashId}) and set as active. Use dashboardId: "${dashId}" on subsequent calls.`,
           },
         ],
       };
@@ -127,11 +133,14 @@ export function registerManageDashboard(server: McpServer): void {
     'set_dashboard_title',
     {
       title: 'Set Dashboard Title',
-      description: 'Set or update the active dashboard title.',
-      inputSchema: { title: z.string().describe('The dashboard title') },
+      description: 'Set or update the dashboard title.',
+      inputSchema: {
+        title: z.string().describe('The dashboard title'),
+        dashboardId: dashboardIdParam,
+      },
     },
     async (args) => {
-      const dashboard = setDashboardTitle(args.title);
+      const dashboard = setDashboardTitle(args.title, args.dashboardId);
       return { content: [{ type: 'text', text: `Dashboard title set to "${dashboard.title}".` }] };
     }
   );
@@ -141,11 +150,14 @@ export function registerManageDashboard(server: McpServer): void {
     'remove_chart',
     {
       title: 'Remove Chart',
-      description: 'Remove a chart from the active dashboard by its id.',
-      inputSchema: { chartId: z.string().describe('The id of the chart to remove') },
+      description: 'Remove a chart from the dashboard by its id.',
+      inputSchema: {
+        chartId: z.string().describe('The id of the chart to remove'),
+        dashboardId: dashboardIdParam,
+      },
     },
     async (args) => {
-      const dashboard = removeChart(args.chartId);
+      const dashboard = removeChart(args.chartId, args.dashboardId);
       return {
         content: [
           {
@@ -162,11 +174,13 @@ export function registerManageDashboard(server: McpServer): void {
     'get_dashboard',
     {
       title: 'Get Dashboard',
-      description: 'Get the active dashboard configuration including all charts.',
-      inputSchema: {},
+      description: 'Get the dashboard configuration including all charts.',
+      inputSchema: {
+        dashboardId: dashboardIdParam,
+      },
     },
-    async () => {
-      const dashboard = getDashboard();
+    async (args) => {
+      const dashboard = getDashboard(args.dashboardId);
       return { content: [{ type: 'text', text: JSON.stringify(dashboard, null, 2) }] };
     }
   );
@@ -176,11 +190,13 @@ export function registerManageDashboard(server: McpServer): void {
     'clear_dashboard',
     {
       title: 'Clear Dashboard',
-      description: 'Remove all charts and reset the active dashboard to a blank state.',
-      inputSchema: {},
+      description: 'Remove all charts and reset the dashboard to a blank state.',
+      inputSchema: {
+        dashboardId: dashboardIdParam,
+      },
     },
-    async () => {
-      clearDashboard();
+    async (args) => {
+      clearDashboard(args.dashboardId);
       return { content: [{ type: 'text', text: 'Dashboard cleared.' }] };
     }
   );

--- a/server/src/tools/view-dashboard.ts
+++ b/server/src/tools/view-dashboard.ts
@@ -6,6 +6,7 @@
 
 import { readFileSync } from 'fs';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
 import {
   registerAppTool,
   registerAppResource,
@@ -78,12 +79,20 @@ export function registerViewDashboard(server: McpServer): void {
         'Display the live dashboard preview inline in the chat. ' +
         'Shows all charts rendered with Elastic Charts in the Kibana grid layout. ' +
         'The preview is interactive — you can see tooltips and hover states.',
+      inputSchema: {
+        dashboardId: z
+          .string()
+          .optional()
+          .describe(
+            'Target dashboard ID for session isolation. If omitted, uses the active dashboard.'
+          ),
+      },
       _meta: {
         ui: { resourceUri: DASHBOARD_RESOURCE_URI },
       },
     },
-    async () => {
-      const dashboard = getDashboard();
+    async (args: { dashboardId?: string }) => {
+      const dashboard = getDashboard(args.dashboardId);
       const chartCount = dashboard.charts.length;
       const sectionCount = (dashboard.sections || []).length;
 

--- a/server/src/utils/dashboard-store.test.ts
+++ b/server/src/utils/dashboard-store.test.ts
@@ -4,8 +4,16 @@
  * you may not use this file except in compliance with the Elastic License 2.0.
  */
 
-import { describe, it, expect } from 'vitest';
-import { slugify } from './dashboard-store.js';
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  slugify,
+  createDashboard,
+  getDashboard,
+  addChart,
+  addSection,
+  clearDashboard,
+} from './dashboard-store.js';
+import type { ChartConfig } from '../types.js';
 
 describe('slugify', () => {
   it('converts title to lowercase slug', () => {
@@ -26,5 +34,69 @@ describe('slugify', () => {
 
   it('trims leading and trailing dashes', () => {
     expect(slugify('--hello--')).toBe('hello');
+  });
+});
+
+describe('session isolation via dashboardId', () => {
+  const chartA: ChartConfig = {
+    id: 'chart-a',
+    title: 'Chart A',
+    chartType: 'bar',
+    esqlQuery: 'FROM logs | STATS count = COUNT(*) BY host',
+    xField: 'host',
+    yFields: ['count'],
+  };
+
+  const chartB: ChartConfig = {
+    id: 'chart-b',
+    title: 'Chart B',
+    chartType: 'line',
+    esqlQuery: 'FROM logs | STATS bytes = SUM(bytes) BY @timestamp',
+    xField: '@timestamp',
+    yFields: ['bytes'],
+  };
+
+  beforeEach(() => {
+    // Create two separate dashboards to simulate parallel sessions
+    createDashboard('Session One', 'session-one');
+    createDashboard('Session Two', 'session-two');
+  });
+
+  it('addChart with dashboardId only affects the targeted dashboard', () => {
+    addChart(chartA, 'session-one');
+    addChart(chartB, 'session-two');
+
+    const one = getDashboard('session-one');
+    const two = getDashboard('session-two');
+
+    expect(one.charts).toHaveLength(1);
+    expect(one.charts[0].id).toBe('chart-a');
+
+    expect(two.charts).toHaveLength(1);
+    expect(two.charts[0].id).toBe('chart-b');
+  });
+
+  it('clearDashboard with dashboardId only clears the targeted dashboard', () => {
+    addChart(chartA, 'session-one');
+    addChart(chartB, 'session-two');
+
+    clearDashboard('session-one');
+
+    const one = getDashboard('session-one');
+    const two = getDashboard('session-two');
+
+    expect(one.charts).toHaveLength(0);
+    expect(two.charts).toHaveLength(1);
+    expect(two.charts[0].id).toBe('chart-b');
+  });
+
+  it('addSection with dashboardId only affects the targeted dashboard', () => {
+    addSection({ id: 'sec-1', title: 'KPIs', collapsed: false, panelIds: [] }, 'session-one');
+
+    const one = getDashboard('session-one');
+    const two = getDashboard('session-two');
+
+    expect(one.sections).toHaveLength(1);
+    expect(two.sections).toHaveLength(0);
   });
 });

--- a/server/src/utils/dashboard-store.ts
+++ b/server/src/utils/dashboard-store.ts
@@ -64,8 +64,13 @@ function emptyDashboard(title = 'Untitled Dashboard'): DashboardConfig {
   return { title, charts: [], sections: [], updatedAt: new Date().toISOString() };
 }
 
-function readDashboard(): DashboardConfig {
-  const id = getActiveDashboardId();
+/** Resolve which dashboard ID to use: explicit override or the global active one. */
+function resolveId(dashboardId?: string): string {
+  return dashboardId ? safeDashboardId(dashboardId) : getActiveDashboardId();
+}
+
+function readDashboard(dashboardId?: string): DashboardConfig {
+  const id = resolveId(dashboardId);
   const path = getDashboardPath(id);
   if (existsSync(path)) {
     const raw = JSON.parse(readFileSync(path, 'utf-8'));
@@ -82,10 +87,10 @@ function atomicWriteSync(filePath: string, data: string): void {
   renameSync(tmp, filePath);
 }
 
-function writeDashboard(config: DashboardConfig): void {
+function writeDashboard(config: DashboardConfig, dashboardId?: string): void {
   ensureDashboardsDir();
   config.updatedAt = new Date().toISOString();
-  const id = getActiveDashboardId();
+  const id = resolveId(dashboardId);
   const json = JSON.stringify(config, null, 2);
   atomicWriteSync(getDashboardPath(id), json);
 }
@@ -156,75 +161,85 @@ export function deleteDashboard(id: string): void {
   }
 }
 
-// ── Panel/section operations (operate on active dashboard) ──
+// ── Panel/section operations ──
+// All functions accept an optional `dashboardId` for session isolation.
+// When provided, they operate on that specific dashboard without changing
+// the global active pointer. When omitted, they use the active dashboard.
 
-export function addChart(chart: PanelConfig): DashboardConfig {
-  const dashboard = readDashboard();
+export function addChart(chart: PanelConfig, dashboardId?: string): DashboardConfig {
+  const dashboard = readDashboard(dashboardId);
   const idx = dashboard.charts.findIndex((c) => c.id === chart.id);
   if (idx >= 0) {
     dashboard.charts[idx] = chart;
   } else {
     dashboard.charts.push(chart);
   }
-  writeDashboard(dashboard);
+  writeDashboard(dashboard, dashboardId);
   return dashboard;
 }
 
-export function removeChart(chartId: string): DashboardConfig {
-  const dashboard = readDashboard();
+export function removeChart(chartId: string, dashboardId?: string): DashboardConfig {
+  const dashboard = readDashboard(dashboardId);
   dashboard.charts = dashboard.charts.filter((c) => c.id !== chartId);
   for (const section of dashboard.sections) {
     section.panelIds = section.panelIds.filter((id) => id !== chartId);
   }
-  writeDashboard(dashboard);
+  writeDashboard(dashboard, dashboardId);
   return dashboard;
 }
 
-export function setDashboardTitle(title: string): DashboardConfig {
-  const dashboard = readDashboard();
+export function setDashboardTitle(title: string, dashboardId?: string): DashboardConfig {
+  const dashboard = readDashboard(dashboardId);
   dashboard.title = title;
-  writeDashboard(dashboard);
+  writeDashboard(dashboard, dashboardId);
   return dashboard;
 }
 
-export function getDashboard(): DashboardConfig {
-  return readDashboard();
+export function getDashboard(dashboardId?: string): DashboardConfig {
+  return readDashboard(dashboardId);
 }
 
-export function clearDashboard(): DashboardConfig {
+export function clearDashboard(dashboardId?: string): DashboardConfig {
   const config = emptyDashboard();
-  writeDashboard(config);
+  writeDashboard(config, dashboardId);
   return config;
 }
 
-export function addSection(section: SectionConfig): DashboardConfig {
-  const dashboard = readDashboard();
+export function addSection(section: SectionConfig, dashboardId?: string): DashboardConfig {
+  const dashboard = readDashboard(dashboardId);
   const idx = dashboard.sections.findIndex((s) => s.id === section.id);
   if (idx >= 0) {
     dashboard.sections[idx] = section;
   } else {
     dashboard.sections.push(section);
   }
-  writeDashboard(dashboard);
+  writeDashboard(dashboard, dashboardId);
   return dashboard;
 }
 
-export function removeSection(sectionId: string): DashboardConfig {
-  const dashboard = readDashboard();
+export function removeSection(sectionId: string, dashboardId?: string): DashboardConfig {
+  const dashboard = readDashboard(dashboardId);
   dashboard.sections = dashboard.sections.filter((s) => s.id !== sectionId);
-  writeDashboard(dashboard);
+  writeDashboard(dashboard, dashboardId);
   return dashboard;
 }
 
-export function saveDashboardLayout(gridLayout: DashboardConfig['gridLayout']): DashboardConfig {
-  const dashboard = readDashboard();
+export function saveDashboardLayout(
+  gridLayout: DashboardConfig['gridLayout'],
+  dashboardId?: string
+): DashboardConfig {
+  const dashboard = readDashboard(dashboardId);
   dashboard.gridLayout = gridLayout;
-  writeDashboard(dashboard);
+  writeDashboard(dashboard, dashboardId);
   return dashboard;
 }
 
-export function movePanelToSection(panelId: string, sectionId: string): DashboardConfig {
-  const dashboard = readDashboard();
+export function movePanelToSection(
+  panelId: string,
+  sectionId: string,
+  dashboardId?: string
+): DashboardConfig {
+  const dashboard = readDashboard(dashboardId);
   for (const section of dashboard.sections) {
     section.panelIds = section.panelIds.filter((id) => id !== panelId);
   }
@@ -232,6 +247,6 @@ export function movePanelToSection(panelId: string, sectionId: string): Dashboar
   if (target) {
     target.panelIds.push(panelId);
   }
-  writeDashboard(dashboard);
+  writeDashboard(dashboard, dashboardId);
   return dashboard;
 }


### PR DESCRIPTION
This PR makes sure that there is a dashboard isolation between different chats (sessions). Till this PR, every chat was showing the active dashboard and it was creating a bad UX. This is changing this.

Session 1 

<img width="901" height="1055" alt="image" src="https://github.com/user-attachments/assets/d8640f99-d5a5-46c4-8457-be6f269e754f" />

Session 2

<img width="882" height="790" alt="image" src="https://github.com/user-attachments/assets/6dde1c13-3e56-4bf4-99bf-69e9bd44ecb7" />


Note: we rely on the AI to use the dashbpard id but it works fine at least at my tests. We are fallbacking to the active one if no id is provided.