### PR TITLE
Add cloud-serverless option to setup wizard

### DIFF
--- a/server/src/setup.ts
+++ b/server/src/setup.ts
@@ -73,11 +73,8 @@ async function main() {
   }
 
   // Choose connection type
-  const defaultConnectionType = existing.ES_CLOUD_ID
-    ? 'cloud-hosted'
-    : existing.ES_NODE && !/^https?:\/\/(localhost|127\.0\.0\.1)/i.test(existing.ES_NODE)
-      ? 'cloud-serverless'
-      : 'local';
+  const defaultConnectionType =
+    existing.CONNECTION_TYPE || (existing.ES_CLOUD_ID ? 'cloud-hosted' : 'local');
   const connectionType = await ask(
     'Connection type (local / cloud-hosted / cloud-serverless)',
     defaultConnectionType
@@ -161,6 +158,7 @@ async function main() {
 
   // Write .env — only include non-empty values
   const envLines: string[] = [];
+  envLines.push(`CONNECTION_TYPE=${connType}`);
   if (cloudId) envLines.push(`ES_CLOUD_ID=${cloudId}`);
   if (esNode) envLines.push(`ES_NODE=${esNode}`);
   if (apiKey) envLines.push(`ES_API_KEY=${apiKey}`);

--- a/server/src/setup.ts
+++ b/server/src/setup.ts
@@ -32,7 +32,9 @@ function ask(question: string, defaultValue?: string): Promise<string> {
   });
 }
 
-async function testConnection(config: ConnectionConfig): Promise<string> {
+async function testConnection(
+  config: ConnectionConfig & { serverless?: boolean }
+): Promise<string> {
   const auth = config.apiKey
     ? { apiKey: config.apiKey }
     : config.username
@@ -44,6 +46,14 @@ async function testConnection(config: ConnectionConfig): Promise<string> {
   const client = config.cloudId
     ? new Client({ cloud: { id: config.cloudId }, auth, tls })
     : new Client({ node: config.node || DEFAULT_ES_NODE, auth, tls });
+
+  if (config.serverless) {
+    // Serverless API keys often lack cluster:monitor privileges needed by
+    // client.info(). Use _has_privileges instead — every authenticated user
+    // can call it on themselves with no extra grants.
+    const res = await client.security.hasPrivileges({ cluster: ['monitor'] });
+    return res.username;
+  }
 
   const info = await client.info();
   return info.cluster_name;
@@ -63,40 +73,52 @@ async function main() {
   }
 
   // Choose connection type
+  const defaultConnectionType = existing.ES_CLOUD_ID
+    ? 'cloud-hosted'
+    : existing.ES_NODE && !/^https?:\/\/(localhost|127\.0\.0\.1)/i.test(existing.ES_NODE)
+      ? 'cloud-serverless'
+      : 'local';
   const connectionType = await ask(
-    'Connection type (local / cloud)',
-    existing.ES_CLOUD_ID ? 'cloud' : 'local'
+    'Connection type (local / cloud-hosted / cloud-serverless)',
+    defaultConnectionType
   );
-  const isCloud = connectionType.toLowerCase() === 'cloud';
+  const connType = connectionType.toLowerCase();
+  const isCloudHosted = connType === 'cloud-hosted';
+  const isServerless = connType === 'cloud-serverless';
 
   let cloudId = '';
   let esNode = '';
-  if (isCloud) {
+  if (isCloudHosted) {
     cloudId = await ask('Cloud ID', existing.ES_CLOUD_ID || '');
+  } else if (isServerless) {
+    esNode = await ask('Elasticsearch URL', existing.ES_NODE || '');
   } else {
     esNode = await ask('Elasticsearch URL', existing.ES_NODE || DEFAULT_ES_NODE);
   }
 
-  // Choose auth type
-  const authType = await ask(
-    'Auth type (password / apikey)',
-    existing.ES_API_KEY ? 'apikey' : 'password'
-  );
-  const useApiKey = authType.toLowerCase() === 'apikey';
-
+  // Choose auth type (serverless always uses API keys)
   let apiKey = '';
   let esUsername = '';
   let esPassword = '';
-  if (useApiKey) {
+  if (isServerless) {
     apiKey = await ask('API Key', existing.ES_API_KEY || '');
   } else {
-    esUsername = await ask('Username', existing.ES_USERNAME || 'elastic');
-    esPassword = await ask('Password', existing.ES_PASSWORD || 'changeme');
+    const authType = await ask(
+      'Auth type (password / apikey)',
+      existing.ES_API_KEY ? 'apikey' : 'password'
+    );
+    const useApiKey = authType.toLowerCase() === 'apikey';
+    if (useApiKey) {
+      apiKey = await ask('API Key', existing.ES_API_KEY || '');
+    } else {
+      esUsername = await ask('Username', existing.ES_USERNAME || 'elastic');
+      esPassword = await ask('Password', existing.ES_PASSWORD || 'changeme');
+    }
   }
 
   const kibanaUrl = await ask(
     'Kibana URL',
-    existing.KIBANA_URL || (isCloud ? '' : DEFAULT_KIBANA_URL)
+    existing.KIBANA_URL || (isCloudHosted || isServerless ? '' : DEFAULT_KIBANA_URL)
   );
 
   // Ask about self-signed certificates when using HTTPS with localhost
@@ -115,15 +137,17 @@ async function main() {
   // Test the connection
   process.stdout.write('\n  Testing connection... ');
   try {
-    const clusterName = await testConnection({
+    const label = await testConnection({
       cloudId: cloudId || undefined,
       node: esNode || undefined,
       apiKey: apiKey || undefined,
       username: esUsername || undefined,
       password: esPassword || undefined,
       unsafeSsl,
+      serverless: isServerless,
     });
-    console.log(`Connected! (cluster: ${clusterName})\n`);
+    const detail = isServerless ? `user: ${label}` : `cluster: ${label}`;
+    console.log(`Connected! (${detail})\n`);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     console.log(`Failed!\n\n  Error: ${message}\n`);


### PR DESCRIPTION
## Summary

- Renames the `cloud` connection type to `cloud-hosted` to distinguish it from serverless
- Adds a new `cloud-serverless` option for Elastic Serverless projects that asks for the Elasticsearch URL and API key directly (no Cloud ID, no username/password prompt)
- Uses `security.hasPrivileges` instead of `client.info()` for the serverless connection test, since scoped Serverless API keys lack the `cluster:monitor` privilege that `client.info()` requires

## Test plan

- [ ] Run `npm run setup` and choose `local` — verify behavior is unchanged
- [ ] Run `npm run setup` and choose `cloud-hosted` — verify it asks for Cloud ID (same as old `cloud` path)
- [x] Run `npm run setup` and choose `cloud-serverless` — verify it asks for ES URL, API key, and Kibana URL (no Cloud ID or auth type prompt)
- [x] Verify the serverless connection test succeeds with a scoped API key
- [x] Re-run `npm run setup` with an existing `.env` from a serverless config — verify it defaults to `cloud-serverless`


Made with [Cursor](https://cursor.com)