### PR TITLE
Quick installation without cloning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch: # Manual trigger to test the build pipeline — no release is created
   push:
     tags:
-      - "v*"
+      - 'v*'
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+name: Release
+
+on:
+  workflow_dispatch: # Manual trigger to test the build pipeline — no release is created
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - run: npm ci
+
+      - name: Build server and preview
+        run: npm run build
+
+      - name: Bundle with esbuild
+        run: bash scripts/bundle.sh
+
+      - name: Pack MCPB bundle
+        run: |
+          npx @anthropic-ai/mcpb pack .
+          echo "MCPB_FILE=$(ls *.mcpb)" >> "$GITHUB_ENV"
+
+      - name: Pack npm tarball
+        run: |
+          npm pack --workspace=server
+          cp mcp-dashboards-server-*.tgz example-mcp-dashbuilder.tgz
+
+      - name: Create GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            "$MCPB_FILE" \
+            example-mcp-dashbuilder.tgz \
+            --title "Elastic Dashbuilder ${{ github.ref_name }}" \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -69,11 +69,37 @@ The MCP App communicates with the server entirely via the MCP Apps protocol (pos
 - Kibana (for export/import)
 - An MCP client: [Cursor](https://cursor.com) (v2.6+ for MCP Apps inline preview), [Claude Desktop](https://claude.ai/download), [Claude Code](https://claude.ai/claude-code), or [VS Code Copilot](https://code.visualstudio.com/)
 
-## Setup
+## Quick install
+
+No need to clone the repo — pick the method that matches your MCP client.
+
+**Claude Desktop:** Download the latest `.mcpb` file from [GitHub Releases](https://github.com/elastic/example-mcp-dashbuilder/releases) and double-click it. Claude Desktop will prompt you for your Elasticsearch credentials.
+
+**Cursor / Claude Code / VS Code:** Point your MCP config at the release tarball — no clone, no npm install:
+
+```json
+{
+  "mcpServers": {
+    "example-mcp-dashbuilder": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "https://github.com/elastic/example-mcp-dashbuilder/releases/latest/download/example-mcp-dashbuilder.tgz"
+      ]
+    }
+  }
+}
+```
+
+Set your Elasticsearch credentials as environment variables (`ES_NODE`, `ES_API_KEY` or `ES_USERNAME`/`ES_PASSWORD`, `KIBANA_URL`) or run `npm run setup` after cloning.
+
+## Setup (from source)
 
 ### 1. Install dependencies
 
 ```bash
+git clone https://github.com/elastic/example-mcp-dashbuilder.git
+cd example-mcp-dashbuilder
 npm install
 ```
 
@@ -127,6 +153,8 @@ No environment variables are needed if you ran `npm run setup` — credentials a
 ```
 
 **Claude Desktop** (`claude_desktop_config.json` — found in `~/Library/Application Support/Claude/` on macOS or `%APPDATA%\Claude\` on Windows):
+
+For the easiest experience, download the `.mcpb` file from [Releases](https://github.com/elastic/example-mcp-dashbuilder/releases). For manual setup from source:
 
 ```json
 {

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,101 @@
+{
+  "manifest_version": "0.3",
+  "name": "example-mcp-dashbuilder",
+  "display_name": "Elastic Dashbuilder",
+  "version": "0.1.0",
+  "description": "AI-powered Kibana dashboard creation via MCP — create, preview, and export ES|QL visualizations through natural language.",
+  "long_description": "An MCP App that lets AI assistants build Kibana dashboards through natural language conversation. Powered by ES|QL and Elastic Charts, it connects to Elasticsearch, explores your data, creates interactive visualizations (bar, line, area, pie, metric, heatmap), and renders live dashboard previews directly in the chat. Dashboards can be exported to Kibana as real Lens visualizations or imported from Kibana for AI-assisted editing.",
+  "author": {
+    "name": "Elastic",
+    "url": "https://www.elastic.co"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/elastic/example-mcp-dashbuilder.git"
+  },
+  "homepage": "https://github.com/elastic/example-mcp-dashbuilder",
+  "support": "https://github.com/elastic/example-mcp-dashbuilder/issues",
+  "server": {
+    "type": "node",
+    "entry_point": "dist/bundle/server.mjs",
+    "mcp_config": {
+      "command": "node",
+      "args": ["${__dirname}/dist/bundle/server.mjs"],
+      "env": {
+        "ES_NODE": "${user_config.es_node}",
+        "ES_API_KEY": "${user_config.es_api_key}",
+        "ES_USERNAME": "${user_config.es_username}",
+        "ES_PASSWORD": "${user_config.es_password}",
+        "KIBANA_URL": "${user_config.kibana_url}"
+      }
+    }
+  },
+  "tools": [
+    { "name": "create_dashboard", "description": "Create a new dashboard" },
+    { "name": "create_chart", "description": "Create bar, line, area, or pie charts" },
+    { "name": "create_metric", "description": "Create metric/KPI panels with sparklines" },
+    { "name": "create_heatmap", "description": "Create heatmap visualizations" },
+    { "name": "run_esql", "description": "Execute ES|QL queries" },
+    { "name": "list_indices", "description": "Discover available indices" },
+    { "name": "get_fields", "description": "Get field mappings for an index" },
+    { "name": "view_dashboard", "description": "Display the live dashboard preview inline" },
+    { "name": "export_to_kibana", "description": "Export to Kibana as Lens visualizations" },
+    { "name": "import_from_kibana", "description": "Import an existing Kibana dashboard" }
+  ],
+  "tools_generated": true,
+  "user_config": {
+    "es_node": {
+      "type": "string",
+      "title": "Elasticsearch URL",
+      "description": "Elasticsearch URL (e.g. http://localhost:9200 or https://your-cluster.es.cloud.example.com)",
+      "required": true,
+      "sensitive": false
+    },
+    "es_api_key": {
+      "type": "string",
+      "title": "Elasticsearch API Key",
+      "description": "API key for authentication (alternative to username/password)",
+      "required": false,
+      "sensitive": true
+    },
+    "es_username": {
+      "type": "string",
+      "title": "Username",
+      "description": "Username for authentication (alternative to API key)",
+      "required": false,
+      "sensitive": false
+    },
+    "es_password": {
+      "type": "string",
+      "title": "Password",
+      "description": "Password for authentication",
+      "required": false,
+      "sensitive": true
+    },
+    "kibana_url": {
+      "type": "string",
+      "title": "Kibana URL",
+      "description": "Kibana URL for export/import (e.g. http://localhost:5601)",
+      "required": false,
+      "sensitive": false
+    }
+  },
+  "keywords": [
+    "dashboard",
+    "elastic",
+    "elasticsearch",
+    "kibana",
+    "esql",
+    "visualization",
+    "charts",
+    "mcp-app"
+  ],
+  "license": "Elastic-2.0",
+  "privacy_policies": ["https://www.elastic.co/legal/privacy-statement"],
+  "compatibility": {
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "node": ">=22.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "format:check": "prettier --check .",
     "test": "npm run test --workspace=server && npm run test --workspace=preview",
     "check": "npm run format:check && npm run lint && npm run typecheck",
+    "bundle": "bash scripts/bundle.sh",
     "postinstall": "npm run build --workspace=preview",
     "prepare": "husky"
   },

--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+# or more contributor license agreements. Licensed under the Elastic License 2.0;
+# you may not use this file except in compliance with the Elastic License 2.0.
+
+# Build a self-contained bundle for distribution (.mcpb / npm tarball).
+# The bundle includes the server JS + all runtime assets (MCP App HTML, ES|QL docs).
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")/.." && pwd)"
+BUNDLE_DIR="$DIR/dist/bundle"
+
+echo "Building server..."
+npm run build --workspace=server
+
+echo "Building preview app..."
+npm run build --workspace=preview
+
+echo "Bundling with esbuild..."
+rm -rf "$BUNDLE_DIR"
+mkdir -p "$BUNDLE_DIR"
+
+npx esbuild "$DIR/server/dist/index.js" \
+  --bundle \
+  --platform=node \
+  --format=esm \
+  --target=node22 \
+  --outfile="$BUNDLE_DIR/server.mjs" \
+  --external:puppeteer \
+  --banner:js="import{createRequire}from'module';const require=createRequire(import.meta.url);"
+
+echo "Copying runtime assets..."
+# MCP App HTML (single-file bundle for inline previews)
+cp "$DIR/preview/dist-mcp-app/index.html" "$BUNDLE_DIR/mcp-app.html"
+
+# ES|QL reference docs
+mkdir -p "$BUNDLE_DIR/esql_docs"
+cp "$DIR/server/src/resources/esql_docs/"*.txt "$BUNDLE_DIR/esql_docs/"
+
+echo "Bundle created at $BUNDLE_DIR"
+ls -lh "$BUNDLE_DIR/server.mjs"

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -5,6 +5,7 @@
  */
 
 import { resolve, dirname } from 'path';
+import { existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 
 /** Project root directory. */
@@ -13,5 +14,11 @@ export const PROJECT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..
 export const DEFAULT_ES_NODE = 'http://localhost:9200';
 export const DEFAULT_KIBANA_URL = 'http://localhost:5601';
 
-/** Path to the pre-built MCP App HTML (single-file bundle for Cursor's chat). */
-export const MCP_APP_HTML_PATH = resolve(PROJECT_ROOT, 'preview', 'dist-mcp-app', 'index.html');
+/**
+ * Path to the pre-built MCP App HTML.
+ * Checks the bundle location first (dist/bundle/mcp-app.html), then
+ * falls back to the dev location (preview/dist-mcp-app/index.html).
+ */
+const BUNDLE_HTML_PATH = resolve(dirname(fileURLToPath(import.meta.url)), 'mcp-app.html');
+const DEV_HTML_PATH = resolve(PROJECT_ROOT, 'preview', 'dist-mcp-app', 'index.html');
+export const MCP_APP_HTML_PATH = existsSync(BUNDLE_HTML_PATH) ? BUNDLE_HTML_PATH : DEV_HTML_PATH;


### PR DESCRIPTION

Adds one-click installation support for Claude Desktop users and tarball-based installation for IDE users, so they don't need to clone the repo.

This adds an extra step for us, we need to release main:

```
  git checkout main
  git pull
  git tag v0.1.0
  git push origin v0.1.0
```