### PR TITLE
Converting elastic dashboards to cursor canvas

### DIFF
--- a/.cursor/skills/elasticsearch-canvas-dashboard/SKILL.md
+++ b/.cursor/skills/elasticsearch-canvas-dashboard/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: elasticsearch-canvas-dashboard
+description: Build standalone Cursor Canvas dashboards from Elasticsearch or ES|QL data, including timerange controls, refresh interactions, KPI/trend/breakdown layout, and optional companion MCP dashboards. Use when the user wants Elasticsearch data, logs, metrics, or ES|QL query results turned into a Canvas dashboard, or wants a live Elastic dashboard mirrored in a canvas.
+---
+
+# Elasticsearch Canvas Dashboard
+
+## Purpose
+
+Use this skill when the deliverable is a `Cursor Canvas` built from Elasticsearch data.
+
+Default to a standalone snapshot canvas.
+
+If the user also wants a live Elastic dashboard, treat that as a companion deliverable, not a replacement for the canvas.
+
+## Quick Start
+
+1. Confirm the data source:
+   - index or index pattern
+   - time field
+   - main KPIs
+   - main trends
+   - main breakdowns
+2. Decide the source of truth:
+   - If a saved dashboard JSON already exists, read it first and mirror its structure.
+   - Otherwise, inspect Elasticsearch fields and validate the ES|QL queries before designing the canvas.
+3. Build the canvas as a self-contained artifact:
+   - exactly one `.canvas.tsx` file
+   - import only from `cursor/canvas`
+   - embed all data inline
+   - no `fetch()`, no network calls
+4. Add lightweight interaction:
+   - timerange selector via `useCanvasState`
+   - refresh button that updates snapshot state or timestamp
+5. Tell the user clearly whether the canvas is:
+   - a live dashboard, or
+   - a standalone snapshot of Elasticsearch data
+
+## Workflow
+
+## 1. Clarify the Deliverable
+
+Choose the path up front:
+
+- `Canvas only`: user wants a standalone artifact in Cursor.
+- `Canvas + MCP dashboard`: user wants a canvas and also wants the live Elastic dashboard preview/export flow.
+- `MCP dashboard only`: do not use this skill unless the user still wants the canvas as part of the result.
+
+For this repository, remember:
+
+- dashboard creation belongs to the MCP workflow
+- the canvas is the standalone presentation layer
+
+## 2. Gather the Data Shape
+
+Prefer the smallest reliable path:
+
+- Read an existing dashboard JSON if one already captures the desired KPI/trend/breakdown shape.
+- Otherwise:
+  - discover indices
+  - inspect fields
+  - test ES|QL queries
+  - confirm time bucketing and aggregation names
+
+For Elasticsearch-driven canvases, capture:
+
+- a primary KPI row
+- 1-2 time-series views
+- 1-2 categorical breakdowns
+- any top-N table that explains the outliers
+
+Keep the canvas focused. Usually 4-8 panels is enough.
+
+## 3. Design the Canvas
+
+Use a dashboard composition that matches the Canvas SDK well:
+
+1. Header:
+   - title
+   - short description
+   - source / coverage / refresh metadata pills
+2. Controls row:
+   - timerange pills or select
+   - refresh button
+3. KPI strip:
+   - `Grid` + `Stat`
+4. Trends:
+   - `LineChart` or `BarChart`
+5. Breakdowns:
+   - `PieChart`, `BarChart`, `Table`
+6. Caveat / note:
+   - `Callout` explaining snapshot vs live behavior
+
+Do not build a wall of identical cards.
+
+Mix open sections with cards. Tables should usually sit directly under a heading unless the table itself is part of a named panel.
+
+## 4. Implement Canvas Interaction
+
+Use `useCanvasState` for persistent controls.
+
+Recommended pattern:
+
+- selected timerange key: `full`, `last30`, `last7`, etc.
+- last refreshed timestamp
+
+The refresh button should:
+
+- update snapshot state when the canvas is static, or
+- only represent a refresh event in the canvas if live querying is not possible
+
+Do not imply live Elasticsearch re-query support unless the canvas really has it.
+
+## 5. Handle Data Correctly
+
+Canvas files must be standalone, so:
+
+- aggregate and normalize data before writing the canvas
+- store only what the canvas needs
+- keep labels preformatted when useful
+- avoid giant raw payload dumps
+
+Good embedded data:
+
+- day labels
+- series arrays
+- KPI totals
+- top-N request rows
+- pie slices
+
+Bad embedded data:
+
+- full unfiltered documents
+- redundant duplicate datasets
+- query results the canvas never renders
+
+## 6. Optional Companion MCP Dashboard
+
+If the user also wants the live Elastic dashboard:
+
+1. Read the project instructions and MCP resources first.
+2. Read:
+   - `dataviz://guidelines`
+   - `esql://reference`
+3. Create a new dashboard with `create_dashboard`.
+4. Pass `dashboardId` on every subsequent tool call.
+5. Build panels with:
+   - `create_metric`
+   - `create_chart`
+   - `create_heatmap`
+   - `create_section`
+6. Always call `view_dashboard`.
+
+Use the MCP dashboard for live querying and export flows.
+
+Use the canvas for the standalone artifact.
+
+## 7. Validation
+
+Before finishing:
+
+- verify the canvas imports only from `cursor/canvas`
+- confirm there is exactly one `.canvas.tsx` file for the artifact
+- check the canvas for lints
+- read the `.canvas.status.json` sidecar if present
+- make sure timerange controls update the displayed snapshot
+- make sure the refresh button has honest behavior
+- mention any limitation around live data explicitly
+
+## Output Pattern
+
+Use this structure by default:
+
+```markdown
+H1 title
+short summary
+metadata pills
+timerange controls + refresh
+KPI grid
+trend section
+breakdown section
+table section
+snapshot/live callout
+```
+
+## Naming Guidance
+
+Prefer descriptive names:
+
+- `logs-operations-overview.canvas.tsx`
+- `search-latency-overview.canvas.tsx`
+- `security-alert-summary.canvas.tsx`
+
+Match the canvas filename to the dashboard topic.
+
+## Additional Resources
+
+- For prompt and layout examples, see [examples.md](examples.md)

--- a/.cursor/skills/elasticsearch-canvas-dashboard/examples.md
+++ b/.cursor/skills/elasticsearch-canvas-dashboard/examples.md
@@ -1,0 +1,61 @@
+# Examples
+
+## Trigger Examples
+
+Use this skill for prompts like:
+
+- "Build a canvas dashboard from my Elasticsearch logs data"
+- "Turn these ES|QL results into a Cursor Canvas"
+- "Mirror this Elastic dashboard in a canvas"
+- "Make a standalone canvas for request latency and error rate"
+- "Create a logs canvas with a timerange filter and refresh button"
+
+## Example Canvas Plan
+
+For a logs dashboard:
+
+1. Read the existing dashboard JSON if it exists.
+2. Validate the source index and time field.
+3. Reduce the data to:
+   - total requests
+   - error rate
+   - average payload size
+   - requests over time
+   - errors over time
+   - status-code mix
+   - top erroring requests
+4. Create a canvas with:
+   - title + context
+   - timerange pills
+   - refresh button
+   - KPI strip
+   - two trend charts
+   - one pie or bar breakdown
+   - one table
+   - callout describing snapshot behavior
+
+## Example User-Facing Caveat
+
+Use wording like:
+
+> This canvas embeds a snapshot of the Elasticsearch-backed dashboard so it can render as a standalone artifact. The timerange filter updates the embedded datasets, and the refresh button updates snapshot state. For live re-querying, use the MCP dashboard preview.
+
+## Example Companion MCP Flow
+
+If the user also wants the live dashboard:
+
+1. Read the MCP resources first.
+2. Create the dashboard.
+3. Use `dashboardId` for every follow-up tool call.
+4. Build metrics, charts, and sections.
+5. Finish with `view_dashboard`.
+
+## Anti-Patterns
+
+Avoid:
+
+- claiming the canvas live-queries Elasticsearch when it does not
+- importing anything except `cursor/canvas`
+- wrapping every section in identical cards
+- embedding far more data than the canvas actually uses
+- skipping the explanation of snapshot vs live behavior

--- a/package-lock.json
+++ b/package-lock.json
@@ -943,6 +943,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -960,6 +961,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -977,6 +979,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -994,6 +997,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1011,6 +1015,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1028,6 +1033,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1045,6 +1051,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1062,6 +1069,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1079,6 +1087,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1096,6 +1105,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1113,6 +1123,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1130,6 +1141,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1147,6 +1159,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1164,6 +1177,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1181,6 +1195,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1198,6 +1213,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1215,6 +1231,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1232,6 +1249,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1249,6 +1267,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1266,6 +1285,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1283,6 +1303,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1300,6 +1321,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1317,6 +1339,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1334,6 +1357,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1351,6 +1375,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1368,6 +1393,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2133,7 +2159,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.0",
@@ -2147,7 +2174,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.0",
@@ -2161,7 +2189,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.0",
@@ -2175,7 +2204,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.0",
@@ -2189,7 +2219,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.0",
@@ -2203,7 +2234,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.0",
@@ -2217,7 +2249,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.0",
@@ -2231,7 +2264,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.0",
@@ -2245,7 +2279,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.0",
@@ -2259,7 +2294,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.0",
@@ -2273,7 +2309,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.0",
@@ -2287,7 +2324,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.0",
@@ -2301,7 +2339,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.0",
@@ -2315,7 +2354,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.0",
@@ -2329,7 +2369,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.0",
@@ -2343,7 +2384,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.0",
@@ -2357,7 +2399,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.0",
@@ -2371,7 +2414,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.0",
@@ -2385,7 +2429,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.0",
@@ -2399,7 +2444,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.0",
@@ -2413,7 +2459,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.0",
@@ -2427,7 +2474,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.0",
@@ -2441,7 +2489,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.0",
@@ -2455,7 +2504,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.0",
@@ -2469,7 +2519,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -5987,6 +6038,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6004,6 +6056,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6021,6 +6074,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6038,6 +6092,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6055,6 +6110,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6072,6 +6128,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6089,6 +6146,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6106,6 +6164,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6123,6 +6182,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6140,6 +6200,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6157,6 +6218,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6174,6 +6236,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6191,6 +6254,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6208,6 +6272,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6225,6 +6290,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6242,6 +6308,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6259,6 +6326,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6276,6 +6344,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6293,6 +6362,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6310,6 +6380,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6327,6 +6398,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6344,6 +6416,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6361,6 +6434,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6378,6 +6452,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6395,6 +6470,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -7169,6 +7245,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -15384,6 +15461,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }

--- a/preview/src/App.tsx
+++ b/preview/src/App.tsx
@@ -95,7 +95,7 @@ export function App({ initialDashboard }: { initialDashboard: DashboardConfig })
 function AppInner({ initialDashboard }: { initialDashboard: DashboardConfig }) {
   const dashboard = initialDashboard;
   const hasCharts = dashboard.charts.length > 0;
-  const { setTimeRange } = useTimeRange();
+  const { refreshData, setTimeRange } = useTimeRange();
   const mcpApp = useMcpApp();
   const { euiTheme } = useEuiTheme();
 
@@ -188,20 +188,29 @@ function AppInner({ initialDashboard }: { initialDashboard: DashboardConfig }) {
             )}
           </EuiFlexItem>
           <EuiFlexItem grow={false}>
-            {isAllData ? (
-              <EuiButtonEmpty iconType="calendar" onClick={() => setIsAllData(false)}>
-                All data
-              </EuiButtonEmpty>
-            ) : (
-              <EuiSuperDatePicker
-                start={start}
-                end={end}
-                onTimeChange={onTimeChange}
-                commonlyUsedRanges={COMMONLY_USED_RANGES}
-                showUpdateButton={false}
-                showTimeWindowButtons={true}
-              />
-            )}
+            <EuiFlexGroup alignItems="center" gutterSize="s" responsive={false}>
+              <EuiFlexItem grow={false}>
+                {isAllData ? (
+                  <EuiButtonEmpty iconType="calendar" onClick={() => setIsAllData(false)}>
+                    All data
+                  </EuiButtonEmpty>
+                ) : (
+                  <EuiSuperDatePicker
+                    start={start}
+                    end={end}
+                    onTimeChange={onTimeChange}
+                    commonlyUsedRanges={COMMONLY_USED_RANGES}
+                    showUpdateButton={false}
+                    showTimeWindowButtons={true}
+                  />
+                )}
+              </EuiFlexItem>
+              <EuiFlexItem grow={false}>
+                <EuiButtonEmpty iconType="refresh" onClick={refreshData}>
+                  Refresh
+                </EuiButtonEmpty>
+              </EuiFlexItem>
+            </EuiFlexGroup>
           </EuiFlexItem>
         </EuiFlexGroup>
       </header>

--- a/preview/src/components/DashboardPanel.tsx
+++ b/preview/src/components/DashboardPanel.tsx
@@ -14,12 +14,17 @@ import { useBuildRenderableConfig } from '../hooks/useBuildRenderableConfig';
 import type { PanelConfig } from '../types';
 
 export function DashboardPanel({ config }: { config: PanelConfig }) {
-  const { timeRange } = useTimeRange();
-  const { data, isLoading, error } = useEsqlQuery(config.esqlQuery, timeRange, config.timeField);
+  const { timeRange, refreshNonce } = useTimeRange();
+  const { data, isLoading, error } = useEsqlQuery(
+    config.esqlQuery,
+    timeRange,
+    config.timeField,
+    refreshNonce
+  );
 
   // Fetch trend data for metrics with a trend query
   const trendQuery = config.chartType === 'metric' ? config.trendEsqlQuery : undefined;
-  const { data: trendData } = useEsqlQuery(trendQuery, timeRange, config.timeField);
+  const { data: trendData } = useEsqlQuery(trendQuery, timeRange, config.timeField, refreshNonce);
 
   const liveConfig = useBuildRenderableConfig(config, data, trendData);
 

--- a/preview/src/context/TimeRangeContext.tsx
+++ b/preview/src/context/TimeRangeContext.tsx
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the Elastic License 2.0.
  */
 
-import React, { createContext, useContext, useState, useMemo } from 'react';
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
 
 export interface TimeRange {
   start: string;
@@ -14,17 +14,29 @@ export interface TimeRange {
 interface TimeRangeContextValue {
   timeRange: TimeRange | null; // null = "all data"
   setTimeRange: (range: TimeRange | null) => void;
+  refreshNonce: number;
+  refreshData: () => void;
 }
 
 const TimeRangeContext = createContext<TimeRangeContextValue>({
   timeRange: null,
   setTimeRange: () => {},
+  refreshNonce: 0,
+  refreshData: () => {},
 });
 
 export function TimeRangeProvider({ children }: { children: React.ReactNode }) {
   const [timeRange, setTimeRange] = useState<TimeRange | null>(null);
+  const [refreshNonce, setRefreshNonce] = useState(0);
 
-  const value = useMemo(() => ({ timeRange, setTimeRange }), [timeRange]);
+  const refreshData = useCallback(() => {
+    setRefreshNonce((value) => value + 1);
+  }, []);
+
+  const value = useMemo(
+    () => ({ timeRange, setTimeRange, refreshNonce, refreshData }),
+    [refreshData, refreshNonce, timeRange]
+  );
 
   return <TimeRangeContext.Provider value={value}>{children}</TimeRangeContext.Provider>;
 }

--- a/preview/src/hooks/useEsqlQuery.ts
+++ b/preview/src/hooks/useEsqlQuery.ts
@@ -20,7 +20,8 @@ interface UseEsqlQueryResult {
 export function useEsqlQuery(
   query: string | undefined,
   timeRange: TimeRange | null,
-  timeField?: string
+  timeField?: string,
+  refreshNonce = 0
 ): UseEsqlQueryResult {
   const [data, setData] = useState<Record<string, unknown>[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -94,7 +95,7 @@ export function useEsqlQuery(
     return () => {
       clearTimeout(timer);
     };
-  }, [query, timeRange, timeField, mcpApp]);
+  }, [query, timeRange, timeField, refreshNonce, mcpApp]);
 
   return { data, isLoading, error };
 }

--- a/server/src/utils/puppeteer-export.ts
+++ b/server/src/utils/puppeteer-export.ts
@@ -41,10 +41,39 @@ function injectExportDataIntoHtml(html: string, exportData: ExportData): string 
   return html.replace('<head>', `<head>${boot}`);
 }
 
-export async function renderChartToPng(exportData: ExportData): Promise<string> {
-  const { default: puppeteer } = await import('puppeteer').catch(() => {
+interface PuppeteerPage {
+  setViewport(viewport: { width: number; height: number }): Promise<void>;
+  setContent(
+    html: string,
+    options: { waitUntil: 'domcontentloaded'; timeout: number }
+  ): Promise<void>;
+  waitForFunction(pageFunction: () => boolean, options: { timeout: number }): Promise<void>;
+  screenshot(options: { type: 'png'; encoding: 'base64'; fullPage: true }): Promise<string>;
+}
+
+interface PuppeteerBrowser {
+  newPage(): Promise<PuppeteerPage>;
+  close(): Promise<void>;
+}
+
+interface PuppeteerModule {
+  default: {
+    launch(options: { headless: boolean; args: string[] }): Promise<PuppeteerBrowser>;
+  };
+}
+
+async function loadPuppeteer(): Promise<PuppeteerModule['default']> {
+  const dynamicImport = new Function('specifier', 'return import(specifier);') as (
+    specifier: string
+  ) => Promise<unknown>;
+  const module = (await dynamicImport('puppeteer').catch(() => {
     throw new Error('Puppeteer is not installed. Run: npm install puppeteer --workspace=server');
-  });
+  })) as PuppeteerModule;
+  return module.default;
+}
+
+export async function renderChartToPng(exportData: ExportData): Promise<string> {
+  const puppeteer = await loadPuppeteer();
 
   const html = readFileSync(MCP_APP_HTML_PATH, 'utf-8');
   const htmlWithExport = injectExportDataIntoHtml(html, exportData);


### PR DESCRIPTION
Don't merge, just testing skills to build native cursor canvas apps.
<img width="1092" height="568" alt="Kapture 2026-04-22 at 15 49 04" src="https://github.com/user-attachments/assets/c0d7207d-01c2-437c-a6b2-b83afad25fd4" />

Some nice things:
- The skill can reuse most of the same behaviors we give for generating dashboards
- Feels more native to cursor

Some bad things:
- It's not live data, can only refresh the snapshot
- It doesn't support very many charts
- Only works in cursor, would likely have a very lossy conversion to kibana dashboards


