### PR TITLE
chore: Add MCP integration tests with testcontainers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,35 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  integration-tests:
+    name: Integration Tests (ES/Kibana ${{ matrix.stack-version }})
+    runs-on: ubuntu-latest
+    needs: check
+    strategy:
+      fail-fast: false
+      matrix:
+        stack-version: ['9.3.0', '9.4.0-SNAPSHOT']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Pull Docker images
+        run: |
+          docker pull docker.elastic.co/elasticsearch/elasticsearch:${{ matrix.stack-version }}
+          docker pull docker.elastic.co/kibana/kibana:${{ matrix.stack-version }}
+
+      - name: Run integration tests
+        working-directory: server
+        env:
+          CI: true
+          STACK_VERSION: ${{ matrix.stack-version }}
+        run: npx vitest run --config vitest.integration.config.ts

--- a/README.md
+++ b/README.md
@@ -289,7 +289,8 @@ Grid positions are preserved 1:1 (same 48-column system). ES|QL queries transfer
 │       │   ├── view-dashboard.ts  # MCP Apps inline preview + resources
 │       │   └── app-only-tools.ts  # App-only tools (visibility: ["app"])
 │       ├── utils/             # ES client, dashboard store, translators
-│       └── resources/         # Instructions, dataviz guidelines, ES|QL ref
+│       ├── resources/         # Instructions, dataviz guidelines, ES|QL ref
+│       └── integration-tests/ # MCP integration tests (testcontainers)
 ├── preview/                   # MCP App (React, built to single HTML file)
 │   ├── vite.mcp-app.config.ts # Single-file build config
 │   └── src/
@@ -327,6 +328,13 @@ npm run format                        # Format all files with Prettier
 npm run format:check                  # Check formatting without writing
 npm run check                         # Run all checks (format + lint + typecheck)
 npm run build --workspace=preview     # Build single-file MCP App
+
+# Integration tests (require Docker)
+cd server
+npm run test:integration              # Run against default stack version
+npm run test:integration:9.3          # Run against ES/Kibana 9.3.0
+npm run test:integration:9.4          # Run against ES/Kibana 9.4.0-SNAPSHOT
+npm run test:integration:all          # Run against both versions sequentially
 ```
 
 ### Testing
@@ -334,14 +342,30 @@ npm run build --workspace=preview     # Build single-file MCP App
 Tests use [Vitest](https://vitest.dev/) and [React Testing Library](https://testing-library.com/docs/react-testing-library/intro/).
 
 ```bash
-npm test                              # Run all tests
-npm run test --workspace=server       # Server tests only
-npm run test --workspace=preview      # Preview tests only
+npm test                              # Run all unit tests
+npm run test --workspace=server       # Server unit tests only
+npm run test --workspace=preview      # Preview unit tests only
 ```
 
-**Server tests** cover pure utility functions (ES|QL transforms, index pattern parsing, time field detection, slugify), the Lens forward/reverse translators, round-trip export-then-import fidelity, and dashboard translation.
+**Server unit tests** cover pure utility functions (ES|QL transforms, index pattern parsing, time field detection, slugify), the Lens forward/reverse translators, round-trip export-then-import fidelity, and dashboard translation.
 
 **Preview tests** cover chart component rendering (correct chart type for each config), the `useEsqlQuery` hook (fetch, loading, error, abort, time range), and empty data states.
+
+#### Integration tests
+
+Integration tests exercise the full MCP client → server → Elasticsearch/Kibana roundtrip using [testcontainers](https://testcontainers.com/). They spin up real ES + Kibana containers with security enabled, seed test data, and interact with the server via `StdioClientTransport`.
+
+```bash
+cd server
+npm run test:integration              # Default stack version
+npm run test:integration:9.3          # ES/Kibana 9.3.0 (saved objects API)
+npm run test:integration:9.4          # ES/Kibana 9.4.0-SNAPSHOT (Dashboard API)
+npm run test:integration:all          # Both versions sequentially
+```
+
+**Requirements:** Docker must be running. First run pulls the ES/Kibana images (~1GB each).
+
+The same test suite runs against both **9.3** (saved objects API path) and **9.4** (new Dashboard API path) to verify both code paths in `export_to_kibana` and `import_from_kibana`. The stack version is configurable via the `STACK_VERSION` env var (or `ES_IMAGE`/`KIBANA_IMAGE` for full control).
 
 ### Releasing
 
@@ -369,7 +393,8 @@ npx semantic-release --dry-run --no-ci
 - `no-explicit-any` enforced via ESLint
 - Prettier formatting enforced
 - Pre-commit hook runs lint-staged (format + lint on staged files)
-- CI pipeline on GitHub Actions (format check + lint + typecheck + build)
+- CI pipeline on GitHub Actions (format check + lint + typecheck + build + tests)
+- Integration tests run against ES/Kibana 9.3 and 9.4 in parallel on CI
 - Emotion theme types properly declared for EUI integration
 
 ## Credits

--- a/package-lock.json
+++ b/package-lock.json
@@ -434,6 +434,13 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@balena/dockerignore/-/dockerignore-1.0.2.tgz",
+      "integrity": "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@base2/pretty-print-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@base2/pretty-print-object/-/pretty-print-object-1.0.1.tgz",
@@ -943,6 +950,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -960,6 +968,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -977,6 +986,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -994,6 +1004,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1011,6 +1022,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1028,6 +1040,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1045,6 +1058,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1062,6 +1076,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1079,6 +1094,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1096,6 +1112,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1113,6 +1130,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1130,6 +1148,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1147,6 +1166,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1164,6 +1184,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1181,6 +1202,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1198,6 +1220,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1215,6 +1238,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1232,6 +1256,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1249,6 +1274,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1266,6 +1292,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1283,6 +1310,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1300,6 +1328,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1317,6 +1346,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1334,6 +1364,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1351,6 +1382,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1368,6 +1400,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1558,6 +1591,58 @@
         }
       }
     },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
+      "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.8.0",
+        "@js-sdsl/ordered-map": "^4.4.2"
+      },
+      "engines": {
+        "node": ">=12.10.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
+      "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.5.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@hello-pangea/dnd": {
       "version": "16.6.0",
       "resolved": "https://registry.npmjs.org/@hello-pangea/dnd/-/dnd-16.6.0.tgz",
@@ -1641,6 +1726,109 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1687,11 +1875,32 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@js-sdsl/ordered-map": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
+      "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
+      }
+    },
     "node_modules/@juggle/resize-observer": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/@juggle/resize-observer/-/resize-observer-3.4.0.tgz",
       "integrity": "sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
     },
     "node_modules/@mapbox/hast-util-table-cell-style": {
       "version": "0.2.1",
@@ -1994,6 +2203,17 @@
         "node": ">=14"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pnpm/config.env-replace": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.1.0.tgz",
@@ -2048,6 +2268,80 @@
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@puppeteer/browsers": {
       "version": "2.13.0",
@@ -2133,7 +2427,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.60.0",
@@ -2147,7 +2442,8 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.60.0",
@@ -2161,7 +2457,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.60.0",
@@ -2175,7 +2472,8 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
       "version": "4.60.0",
@@ -2189,7 +2487,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
       "version": "4.60.0",
@@ -2203,7 +2502,8 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.60.0",
@@ -2217,7 +2517,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
       "version": "4.60.0",
@@ -2231,7 +2532,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.60.0",
@@ -2245,7 +2547,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.60.0",
@@ -2259,7 +2562,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
       "version": "4.60.0",
@@ -2273,7 +2577,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
       "version": "4.60.0",
@@ -2287,7 +2592,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
       "version": "4.60.0",
@@ -2301,7 +2607,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
       "version": "4.60.0",
@@ -2315,7 +2622,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.60.0",
@@ -2329,7 +2637,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
       "version": "4.60.0",
@@ -2343,7 +2652,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
       "version": "4.60.0",
@@ -2357,7 +2667,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.60.0",
@@ -2371,7 +2682,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.60.0",
@@ -2385,7 +2697,8 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
       "version": "4.60.0",
@@ -2399,7 +2712,8 @@
       "optional": true,
       "os": [
         "openbsd"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
       "version": "4.60.0",
@@ -2413,7 +2727,8 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.60.0",
@@ -2427,7 +2742,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.60.0",
@@ -2441,7 +2757,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
       "version": "4.60.0",
@@ -2455,7 +2772,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.60.0",
@@ -2469,7 +2787,8 @@
       "optional": true,
       "os": [
         "win32"
-      ]
+      ],
+      "peer": true
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -3401,6 +3720,16 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@testcontainers/elasticsearch": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/@testcontainers/elasticsearch/-/elasticsearch-11.14.0.tgz",
+      "integrity": "sha512-S+bnwhcO9NjcKpnDd6yviQvmHzFW0V8wA3ZDX2YxBalMKcnRVPHjBohO+pJGnYBWryMi+16qNmbuuDuY8ppRDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "testcontainers": "^11.14.0"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -3567,6 +3896,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/docker-modem": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/docker-modem/-/docker-modem-3.0.6.tgz",
+      "integrity": "sha512-yKpAGEuKRSS8wwx0joknWxsmLha78wNMe9R2S3UNsVOkZded8UqOrV8KoeDXoXsjndxwyF3eIhyClGbO1SEhEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
+    "node_modules/@types/dockerode": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/dockerode/-/dockerode-4.0.1.tgz",
+      "integrity": "sha512-cmUpB+dPN955PxBEuXE3f6lKO1hHiIGYJA46IVF3BJpNsZGvtBDcRnlrHYHtOH/B6vtDOyl2kZ2ShAu3mgc27Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/docker-modem": "*",
+        "@types/node": "*",
+        "@types/ssh2": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3700,6 +4052,43 @@
       "dependencies": {
         "@types/prismjs": "*"
       }
+    },
+    "node_modules/@types/ssh2": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-1.15.5.tgz",
+      "integrity": "sha512-N1ASjp/nXH3ovBHddRJpli4ozpk6UdDYIX4RJWFa9L1YKnzdhTlVmiGHm4DZnj/jLbqZpes4aeR30EFGQtvhQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18"
+      }
+    },
+    "node_modules/@types/ssh2-streams": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/ssh2-streams/-/ssh2-streams-0.1.13.tgz",
+      "integrity": "sha512-faHyY3brO9oLEA0QlcO8N2wT7R0+1sHWZvQ+y3rMLwdY1ZyS1z0W3t65j9PqT4HmQ6ALzNe7RZlNuCNE0wBSWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/ssh2/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "2.0.11",
@@ -4159,6 +4548,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -4344,6 +4746,163 @@
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
+    "node_modules/archiver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
+      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.2",
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^6.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
+      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.0.0",
+        "graceful-fs": "^4.2.0",
+        "is-stream": "^2.0.1",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.17.15",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/archiver/node_modules/buffer-crc32": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/archiver/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/archiver/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4396,6 +4955,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/asn1": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
+      "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4418,6 +4987,20 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/attr-accept": {
       "version": "2.2.5",
@@ -4464,8 +5047,8 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
       "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -4479,8 +5062,8 @@
       "version": "4.7.1",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
       "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
@@ -4504,8 +5087,8 @@
       "version": "3.8.7",
       "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
       "integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -4514,8 +5097,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
@@ -4524,8 +5107,8 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
       "integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "streamx": "^2.25.0",
         "teex": "^1.0.1"
@@ -4551,11 +5134,32 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
       "integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.10",
@@ -4580,6 +5184,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tweetnacl": "^0.14.3"
+      }
+    },
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
@@ -4601,6 +5215,58 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/body-parser": {
@@ -4692,6 +5358,31 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -4700,6 +5391,26 @@
       "optional": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/buildcheck": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
+      "integrity": "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/byline": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/bytes": {
@@ -4870,6 +5581,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/chroma-js": {
       "version": "2.6.0",
@@ -5084,8 +5802,8 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -5197,6 +5915,84 @@
       "dependencies": {
         "array-ify": "^1.0.0",
         "dot-prop": "^5.1.0"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
+      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^6.0.0",
+        "is-stream": "^2.0.1",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/compress-commons/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/compress-commons/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/compress-commons/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/compress-commons/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/concat-map": {
@@ -5396,6 +6192,96 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/cpu-features": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.10.tgz",
+      "integrity": "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "buildcheck": "~0.0.6",
+        "nan": "^2.19.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
+      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/crc32-stream/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/crc32-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -5735,6 +6621,128 @@
         "node": ">=8"
       }
     },
+    "node_modules/docker-compose": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/docker-compose/-/docker-compose-1.4.2.tgz",
+      "integrity": "sha512-rPHigTKGaEHpkUmfd69QgaOp+Os5vGJwG/Ry8lcr8W/382AmI+z/D7qoa9BybKIkqNppaIbs8RYeHSevdQjWww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yaml": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/docker-modem": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-5.0.7.tgz",
+      "integrity": "sha512-XJgGhoR/CLpqshm4d3L7rzH6t8NgDFUIIpztYlLHIApeJjMZKYJMz2zxPsYxnejq5h3ELYSw/RBsi3t5h7gNTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "readable-stream": "^3.5.0",
+        "split-ca": "^1.0.1",
+        "ssh2": "^1.15.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/docker-modem/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-4.0.10.tgz",
+      "integrity": "sha512-8L/P9JynLBiG7/coiA4FlQXegHltRqS0a+KqI44P1zgQh8QLHTg7FKOwhkBgSJwZTeHsq30WRoVFLuwkfK0YFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@grpc/grpc-js": "^1.11.1",
+        "@grpc/proto-loader": "^0.7.13",
+        "docker-modem": "^5.0.7",
+        "protobufjs": "^7.3.2",
+        "tar-fs": "^2.1.4",
+        "uuid": "^10.0.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/dockerode/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/dockerode/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dockerode/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -5779,6 +6787,13 @@
       "dependencies": {
         "readable-stream": "^2.0.2"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -5830,8 +6845,8 @@
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -5987,6 +7002,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6004,6 +7020,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6021,6 +7038,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6038,6 +7056,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6055,6 +7074,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6072,6 +7092,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6089,6 +7110,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6106,6 +7128,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6123,6 +7146,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6140,6 +7164,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6157,6 +7182,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6174,6 +7200,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6191,6 +7218,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6208,6 +7236,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6225,6 +7254,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6242,6 +7272,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6259,6 +7290,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6276,6 +7308,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6293,6 +7326,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6310,6 +7344,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6327,6 +7362,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6344,6 +7380,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6361,6 +7398,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6378,6 +7416,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6395,6 +7434,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -6670,6 +7710,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -6677,12 +7727,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/events-universal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.7.0"
       }
@@ -6870,8 +7930,8 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -7115,6 +8175,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -7144,6 +8221,13 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fs-extra": {
       "version": "11.3.4",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
@@ -7169,6 +8253,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -7261,6 +8346,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-port": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/get-port/-/get-port-7.2.0.tgz",
+      "integrity": "sha512-afP4W205ONCuMoPBqcR6PSXnzX35KTcJygfJfcp+QY+uwm3p20p1YczWXhlICIzGMCxYBQcySEcOgsJcrkyobg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -7333,6 +8431,28 @@
         "traverse": "0.6.8"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -7344,6 +8464,32 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/globals": {
@@ -7778,6 +8924,27 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -8180,6 +9347,22 @@
         "node": "^18.17 || >=20.6.1"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/java-properties": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/java-properties/-/java-properties-1.0.2.tgz",
@@ -8382,6 +9565,19 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
       }
     },
     "node_modules/levn": {
@@ -8806,6 +10002,13 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -9204,12 +10407,45 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/moment": {
       "version": "2.30.1",
@@ -9251,6 +10487,14 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/nan": {
+      "version": "2.26.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
+      "integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -9353,6 +10597,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/normalize-url": {
@@ -11576,6 +12830,13 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -11686,6 +12947,30 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/path-to-regexp": {
       "version": "8.4.1",
@@ -11958,6 +13243,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -11992,6 +13287,43 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/properties-reader": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/properties-reader/-/properties-reader-3.0.1.tgz",
+      "integrity": "sha512-WPn+h9RGEExOKdu4bsF4HksG/uzd3cFq3MFtq8PsFeExPse5Ha/VOjQNyHhjboBFwGXGev6muJYTSPAOkROq2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "mkdirp": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/properties?sponsor=1"
+      }
+    },
     "node_modules/property-information": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.6.0.tgz",
@@ -12011,6 +13343,31 @@
       "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -12066,8 +13423,8 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -12596,6 +13953,39 @@
         "util-deprecate": "~1.0.1"
       }
     },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -12871,6 +14261,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rfdc": {
@@ -14051,6 +15451,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/split-ca": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split-ca/-/split-ca-1.0.1.tgz",
+      "integrity": "sha512-Q5thBSxp5t8WPTTJQS59LrGqOZqOsrhDGDVm8azCqIBjSBd7nd9o2PM+mDulQQkh8h//4U6hFZnc/mul8t5pWQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/split2": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-1.0.0.tgz",
@@ -14059,6 +15466,46 @@
       "license": "ISC",
       "dependencies": {
         "through2": "~2.0.0"
+      }
+    },
+    "node_modules/ssh-remote-port-forward": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/ssh-remote-port-forward/-/ssh-remote-port-forward-1.0.4.tgz",
+      "integrity": "sha512-x0LV1eVDwjf1gmG7TTnfqIzf+3VPRz7vrNIjX6oYLbeCrf/PeVY6hkT68Mg+q02qXxQhrLjB0jfgvhevoCRmLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ssh2": "^0.5.48",
+        "ssh2": "^1.4.0"
+      }
+    },
+    "node_modules/ssh-remote-port-forward/node_modules/@types/ssh2": {
+      "version": "0.5.52",
+      "resolved": "https://registry.npmjs.org/@types/ssh2/-/ssh2-0.5.52.tgz",
+      "integrity": "sha512-lbLLlXxdCZOSJMCInKH2+9V/77ET2J6NPQHpFI0kda61Dd1KglJs+fPQBchizmzYSOJBgdTajhPqBO1xxLywvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/ssh2-streams": "*"
+      }
+    },
+    "node_modules/ssh2": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.17.0.tgz",
+      "integrity": "sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "asn1": "^0.2.6",
+        "bcrypt-pbkdf": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "optionalDependencies": {
+        "cpu-features": "~0.0.10",
+        "nan": "^2.23.0"
       }
     },
     "node_modules/stackback": {
@@ -14109,8 +15556,8 @@
       "version": "2.25.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
       "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
@@ -14152,6 +15599,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-3.1.0.tgz",
@@ -14172,6 +15635,20 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -14346,8 +15823,8 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
       "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -14361,8 +15838,8 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
       "integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "b4a": "^1.6.4",
         "bare-fs": "^4.5.5",
@@ -14374,8 +15851,8 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
       "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -14389,8 +15866,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "streamx": "^2.12.5"
       }
@@ -14437,12 +15914,36 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/testcontainers": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/testcontainers/-/testcontainers-11.14.0.tgz",
+      "integrity": "sha512-r9pniwv/iwzyHaI7gwAvAm4Y+IvjJg3vBWdjrUCaDMc2AXIr4jKbq7jJO18Mw2ybs73pZy1Aj7p/4RVBGMRWjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@balena/dockerignore": "^1.0.2",
+        "@types/dockerode": "^4.0.1",
+        "archiver": "^7.0.1",
+        "async-lock": "^1.4.1",
+        "byline": "^5.0.0",
+        "debug": "^4.4.3",
+        "docker-compose": "^1.4.2",
+        "dockerode": "^4.0.10",
+        "get-port": "^7.2.0",
+        "proper-lockfile": "^4.1.2",
+        "properties-reader": "^3.0.1",
+        "ssh-remote-port-forward": "^1.0.4",
+        "tar-fs": "^3.1.2",
+        "tmp": "^0.2.5",
+        "undici": "^7.24.5"
+      }
+    },
     "node_modules/text-decoder": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "b4a": "^1.6.4"
       }
@@ -14451,8 +15952,8 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
       "integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -14587,6 +16088,16 @@
       "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -14739,6 +16250,13 @@
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
       }
+    },
+    "node_modules/tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -15384,6 +16902,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -15660,6 +17179,25 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -15751,8 +17289,8 @@
       "version": "17.7.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -15770,8 +17308,8 @@
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -15811,6 +17349,69 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
+      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "archiver-utils": "^5.0.0",
+        "compress-commons": "^6.0.2",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/zip-stream/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/zip-stream/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/zip-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/zod": {
@@ -15878,7 +17479,9 @@
         "zod": "^3.24.0"
       },
       "devDependencies": {
+        "@testcontainers/elasticsearch": "^11.14.0",
         "@types/node": "^22.0.0",
+        "testcontainers": "^11.14.0",
         "tsx": "^4.19.0",
         "typescript": "^5.7.0",
         "vitest": "^4.1.2"

--- a/server/package.json
+++ b/server/package.json
@@ -8,21 +8,28 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
+    "test:integration:watch": "vitest --config vitest.integration.config.ts",
+    "test:integration:9.3": "STACK_VERSION=9.3.0 vitest run --config vitest.integration.config.ts",
+    "test:integration:9.4": "STACK_VERSION=9.4.0-SNAPSHOT vitest run --config vitest.integration.config.ts",
+    "test:integration:all": "npm run test:integration:9.3 && npm run test:integration:9.4"
   },
   "dependencies": {
-    "mcp-dashboards-shared": "*",
     "@elastic/elasticsearch": "^9.0.0",
     "@elastic/esql": "^1.7.0",
     "@modelcontextprotocol/ext-apps": "^1.5.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "mcp-dashboards-shared": "*",
     "zod": "^3.24.0"
   },
   "optionalDependencies": {
     "puppeteer": "^24.0.0"
   },
   "devDependencies": {
+    "@testcontainers/elasticsearch": "^11.14.0",
     "@types/node": "^22.0.0",
+    "testcontainers": "^11.14.0",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.2"

--- a/server/src/integration-tests/__fixtures__/dashboard-factory.ts
+++ b/server/src/integration-tests/__fixtures__/dashboard-factory.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import { TEST_INDEX } from '../setup/seed-data.js';
+
+/**
+ * Sample tool arguments for integration tests.
+ * All queries target the `test_ecommerce` index seeded by global setup.
+ */
+
+export const SAMPLE_BAR_CHART_ARGS = {
+  title: 'Revenue by Category',
+  chartType: 'bar' as const,
+  esqlQuery: `FROM ${TEST_INDEX} | STATS revenue = SUM(taxful_total_price) BY category`,
+  xField: 'category',
+  yFields: ['revenue'],
+};
+
+export const SAMPLE_LINE_CHART_ARGS = {
+  title: 'Orders Over Time',
+  chartType: 'line' as const,
+  esqlQuery: `FROM ${TEST_INDEX} | STATS orders = COUNT(*) BY order_date = BUCKET(order_date, 1 day)`,
+  xField: 'order_date',
+  yFields: ['orders'],
+};
+
+export const SAMPLE_METRIC_ARGS = {
+  title: 'Total Revenue',
+  esqlQuery: `FROM ${TEST_INDEX} | STATS total = SUM(taxful_total_price)`,
+  valueField: 'total',
+  format: 'currency' as const,
+};
+
+export const SAMPLE_HEATMAP_ARGS = {
+  title: 'Category by Gender',
+  esqlQuery: `FROM ${TEST_INDEX} | STATS count = COUNT(*) BY category, customer_gender`,
+  xField: 'category',
+  yField: 'customer_gender',
+  valueField: 'count',
+};
+
+export const SAMPLE_SECTION_ARGS = {
+  title: 'Overview',
+};
+
+export const INVALID_ESQL_QUERY = 'FROM nonexistent_index_xyz | STATS count = COUNT(*)';

--- a/server/src/integration-tests/helpers/mcp-assertions.ts
+++ b/server/src/integration-tests/helpers/mcp-assertions.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import { expect } from 'vitest';
+import type { CallToolResult, ListToolsResult } from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * Extract the first text content block from a tool result.
+ */
+export function expectTextContent(result: CallToolResult): string {
+  const text = result.content.find((c) => c.type === 'text');
+  expect(text, 'Expected at least one text content block').toBeDefined();
+  return (text as { type: 'text'; text: string }).text;
+}
+
+/**
+ * Assert the tool call did not return an error.
+ */
+export function expectNoError(result: CallToolResult): void {
+  expect(result.isError, `Tool returned error: ${JSON.stringify(result.content)}`).toBeFalsy();
+}
+
+/**
+ * Assert a tool call succeeded and return its text content.
+ */
+export function expectSuccess(result: CallToolResult): string {
+  expectNoError(result);
+  return expectTextContent(result);
+}
+
+/**
+ * Assert a named tool exists in the tools list.
+ */
+export function expectToolExists(tools: ListToolsResult, name: string): void {
+  const names = tools.tools.map((t) => t.name);
+  expect(names, `Tool "${name}" should be registered`).toContain(name);
+}
+
+/**
+ * Assert multiple tools exist.
+ */
+export function expectToolsExist(tools: ListToolsResult, names: string[]): void {
+  for (const name of names) {
+    expectToolExists(tools, name);
+  }
+}
+
+/**
+ * Parse a JSON text content block from a tool result.
+ */
+export function parseJsonContent<T = unknown>(result: CallToolResult): T {
+  const text = expectTextContent(result);
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    // Not JSON — return text as-is (many tools return plain text)
+    return text as unknown as T;
+  }
+}

--- a/server/src/integration-tests/helpers/mcp-assertions.ts
+++ b/server/src/integration-tests/helpers/mcp-assertions.ts
@@ -56,7 +56,6 @@ export function parseJsonContent<T = unknown>(result: CallToolResult): T {
   try {
     return JSON.parse(text) as T;
   } catch {
-    // Not JSON — return text as-is (many tools return plain text)
-    return text as unknown as T;
+    throw new Error(`Expected JSON content but got: ${text.slice(0, 200)}`);
   }
 }

--- a/server/src/integration-tests/setup/global.ts
+++ b/server/src/integration-tests/setup/global.ts
@@ -10,6 +10,8 @@ import type { StartedTestContainer, StartedNetwork } from 'testcontainers';
 
 import { seedTestData } from './seed-data.js';
 
+const ES_PASSWORD = 'changeme';
+
 // Disable Ryuk sidecar — our teardown() handles container cleanup.
 // This also avoids Docker Desktop "enhanced container isolation" blocks.
 process.env.TESTCONTAINERS_RYUK_DISABLED = 'true';
@@ -51,10 +53,10 @@ export async function setup(): Promise<void> {
   console.log(`🐳 Starting Elasticsearch: ${esImage}`);
 
   const esStarted = await new ElasticsearchContainer(esImage)
+    .withPassword(ES_PASSWORD)
     .withNetwork(net)
     .withNetworkAliases('elasticsearch')
     .withEnvironment({
-      'xpack.security.enabled': 'false',
       'xpack.license.self_generated.type': 'trial',
     })
     .withStartupTimeout(120_000)
@@ -64,10 +66,22 @@ export async function setup(): Promise<void> {
 
   const esUrl = `http://${esStarted.getHost()}:${esStarted.getMappedPort(9200)}`;
   process.env.ES_NODE = esUrl;
-  console.log(`✅ Elasticsearch ready at ${esUrl}`);
+  process.env.ES_USERNAME = 'elastic';
+  process.env.ES_PASSWORD = ES_PASSWORD;
+  console.log(`✅ Elasticsearch ready at ${esUrl} (security enabled)`);
+
+  // Set kibana_system password so Kibana can connect with security enabled
+  await fetch(`${esUrl}/_security/user/kibana_system/_password`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${Buffer.from(`elastic:${ES_PASSWORD}`).toString('base64')}`,
+    },
+    body: JSON.stringify({ password: ES_PASSWORD }),
+  });
 
   // Seed test data before starting Kibana so indices exist
-  await seedTestData(esUrl);
+  await seedTestData(esUrl, ES_PASSWORD);
 
   console.log(`🐳 Starting Kibana: ${kibanaImage}`);
 
@@ -75,12 +89,16 @@ export async function setup(): Promise<void> {
     .withNetwork(net)
     .withEnvironment({
       ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200',
-      'xpack.security.enabled': 'false',
+      ELASTICSEARCH_USERNAME: 'kibana_system',
+      ELASTICSEARCH_PASSWORD: ES_PASSWORD,
       'server.host': '0.0.0.0',
     })
     .withExposedPorts(5601)
     .withWaitStrategy(
-      Wait.forHttp('/api/status', 5601).forStatusCode(200).withStartupTimeout(180_000)
+      Wait.forHttp('/api/status', 5601)
+        .forStatusCode(200)
+        .withBasicCredentials('elastic', ES_PASSWORD)
+        .withStartupTimeout(180_000)
     )
     .withStartupTimeout(180_000)
     .start();

--- a/server/src/integration-tests/setup/global.ts
+++ b/server/src/integration-tests/setup/global.ts
@@ -4,6 +4,98 @@
  * you may not use this file except in compliance with the Elastic License 2.0.
  */
 
-// Placeholder — implemented in subtask 2
-export async function setup(): Promise<void> {}
-export async function teardown(): Promise<void> {}
+import { ElasticsearchContainer } from '@testcontainers/elasticsearch';
+import { GenericContainer, Network, Wait } from 'testcontainers';
+import type { StartedTestContainer, StartedNetwork } from 'testcontainers';
+
+import { seedTestData } from './seed-data.js';
+
+// Disable Ryuk sidecar — our teardown() handles container cleanup.
+// This also avoids Docker Desktop "enhanced container isolation" blocks.
+process.env.TESTCONTAINERS_RYUK_DISABLED = 'true';
+
+/**
+ * Resolve the Docker image tag for a given component.
+ *
+ * Priority:
+ *   1. Component-specific env var (ES_IMAGE / KIBANA_IMAGE)
+ *   2. STACK_VERSION env var  (e.g. "9.4.0-SNAPSHOT")
+ *   3. Default fallback
+ */
+const DEFAULT_STACK_VERSION = '9.0.0';
+
+function resolveEsImage(): string {
+  if (process.env.ES_IMAGE) return process.env.ES_IMAGE;
+  const version = process.env.STACK_VERSION || DEFAULT_STACK_VERSION;
+  return `docker.elastic.co/elasticsearch/elasticsearch:${version}`;
+}
+
+function resolveKibanaImage(): string {
+  if (process.env.KIBANA_IMAGE) return process.env.KIBANA_IMAGE;
+  const version = process.env.STACK_VERSION || DEFAULT_STACK_VERSION;
+  return `docker.elastic.co/kibana/kibana:${version}`;
+}
+
+let network: StartedNetwork | undefined;
+let esContainer: StartedTestContainer | undefined;
+let kibanaContainer: StartedTestContainer | undefined;
+
+export async function setup(): Promise<void> {
+  const esImage = resolveEsImage();
+  const kibanaImage = resolveKibanaImage();
+
+  // Create a shared Docker network so Kibana can reach ES by hostname
+  const net = await new Network().start();
+  network = net;
+
+  console.log(`🐳 Starting Elasticsearch: ${esImage}`);
+
+  const esStarted = await new ElasticsearchContainer(esImage)
+    .withNetwork(net)
+    .withNetworkAliases('elasticsearch')
+    .withEnvironment({
+      'xpack.security.enabled': 'false',
+      'xpack.license.self_generated.type': 'trial',
+    })
+    .withStartupTimeout(120_000)
+    .start();
+
+  esContainer = esStarted;
+
+  const esUrl = `http://${esStarted.getHost()}:${esStarted.getMappedPort(9200)}`;
+  process.env.ES_NODE = esUrl;
+  console.log(`✅ Elasticsearch ready at ${esUrl}`);
+
+  // Seed test data before starting Kibana so indices exist
+  await seedTestData(esUrl);
+
+  console.log(`🐳 Starting Kibana: ${kibanaImage}`);
+
+  const kbStarted = await new GenericContainer(kibanaImage)
+    .withNetwork(net)
+    .withEnvironment({
+      ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200',
+      'xpack.security.enabled': 'false',
+      'server.host': '0.0.0.0',
+    })
+    .withExposedPorts(5601)
+    .withWaitStrategy(
+      Wait.forHttp('/api/status', 5601).forStatusCode(200).withStartupTimeout(180_000)
+    )
+    .withStartupTimeout(180_000)
+    .start();
+
+  kibanaContainer = kbStarted;
+
+  const kibanaUrl = `http://${kbStarted.getHost()}:${kbStarted.getMappedPort(5601)}`;
+  process.env.KIBANA_URL = kibanaUrl;
+  console.log(`✅ Kibana ready at ${kibanaUrl}`);
+}
+
+export async function teardown(): Promise<void> {
+  console.log('🧹 Tearing down containers…');
+  await kibanaContainer?.stop();
+  await esContainer?.stop();
+  await network?.stop();
+  console.log('✅ Containers stopped');
+}

--- a/server/src/integration-tests/setup/global.ts
+++ b/server/src/integration-tests/setup/global.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+// Placeholder — implemented in subtask 2
+export async function setup(): Promise<void> {}
+export async function teardown(): Promise<void> {}

--- a/server/src/integration-tests/setup/seed-data.ts
+++ b/server/src/integration-tests/setup/seed-data.ts
@@ -89,7 +89,8 @@ function generateDocs(count: number): EcommerceDoc[] {
 
 export const TEST_INDEX = 'test_ecommerce';
 
-export async function seedTestData(esUrl: string): Promise<void> {
+export async function seedTestData(esUrl: string, password: string): Promise<void> {
+  const authHeader = `Basic ${Buffer.from(`elastic:${password}`).toString('base64')}`;
   console.log(`🌱 Seeding ${TEST_INDEX} index…`);
 
   // Create index with explicit mappings
@@ -123,7 +124,7 @@ export async function seedTestData(esUrl: string): Promise<void> {
 
   const createRes = await fetch(`${esUrl}/${TEST_INDEX}`, {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', Authorization: authHeader },
     body: JSON.stringify(mappings),
   });
 
@@ -143,7 +144,7 @@ export async function seedTestData(esUrl: string): Promise<void> {
 
   const bulkRes = await fetch(`${esUrl}/_bulk`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-ndjson' },
+    headers: { 'Content-Type': 'application/x-ndjson', Authorization: authHeader },
     body: bulkBody,
   });
 
@@ -152,7 +153,10 @@ export async function seedTestData(esUrl: string): Promise<void> {
   }
 
   // Refresh to make docs searchable
-  await fetch(`${esUrl}/${TEST_INDEX}/_refresh`, { method: 'POST' });
+  await fetch(`${esUrl}/${TEST_INDEX}/_refresh`, {
+    method: 'POST',
+    headers: { Authorization: authHeader },
+  });
 
   console.log(`✅ Seeded ${docs.length} documents into ${TEST_INDEX}`);
 }

--- a/server/src/integration-tests/setup/seed-data.ts
+++ b/server/src/integration-tests/setup/seed-data.ts
@@ -121,11 +121,15 @@ export async function seedTestData(esUrl: string): Promise<void> {
     },
   };
 
-  await fetch(`${esUrl}/${TEST_INDEX}`, {
+  const createRes = await fetch(`${esUrl}/${TEST_INDEX}`, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(mappings),
   });
+
+  if (!createRes.ok) {
+    throw new Error(`Index creation failed: ${createRes.status} ${await createRes.text()}`);
+  }
 
   // Bulk index documents
   const docs = generateDocs(20);

--- a/server/src/integration-tests/setup/seed-data.ts
+++ b/server/src/integration-tests/setup/seed-data.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+/**
+ * Seed a small `test_ecommerce` index with documents covering
+ * the field types the MCP tools expect: keyword, date, numeric, geo_point.
+ */
+
+interface EcommerceDoc {
+  order_date: string;
+  customer_first_name: string;
+  customer_last_name: string;
+  customer_gender: string;
+  category: string;
+  currency: string;
+  products: Array<{
+    product_name: string;
+    price: number;
+    quantity: number;
+  }>;
+  taxful_total_price: number;
+  order_id: string;
+  geoip: { location: { lat: number; lon: number } };
+}
+
+const CATEGORIES = ["Men's Clothing", "Women's Clothing", "Men's Shoes", "Women's Accessories"];
+const CURRENCIES = ['EUR', 'USD', 'GBP'];
+const NAMES_FIRST = ['Eddie', 'Mary', 'Gwen', 'Diane', 'Stephanie', 'Jim', 'Oliver', 'Sonya'];
+const NAMES_LAST = [
+  'Underwood',
+  'Bailey',
+  'Butler',
+  'Chandler',
+  'Evans',
+  'Foster',
+  'Grant',
+  'Hart',
+];
+const PRODUCTS = [
+  'Basic T-Shirt',
+  'Casual Sneakers',
+  'Leather Belt',
+  'Denim Jacket',
+  'Wool Scarf',
+  'Running Shoes',
+  'Cotton Hoodie',
+  'Canvas Bag',
+];
+
+function generateDocs(count: number): EcommerceDoc[] {
+  const docs: EcommerceDoc[] = [];
+  const baseDate = new Date('2025-01-01T00:00:00Z');
+
+  for (let i = 0; i < count; i++) {
+    const date = new Date(baseDate.getTime() + i * 86_400_000);
+    const price = Math.round((10 + Math.random() * 190) * 100) / 100;
+    const qty = 1 + Math.floor(Math.random() * 3);
+
+    docs.push({
+      order_date: date.toISOString(),
+      customer_first_name: NAMES_FIRST[i % NAMES_FIRST.length],
+      customer_last_name: NAMES_LAST[i % NAMES_LAST.length],
+      customer_gender: i % 2 === 0 ? 'MALE' : 'FEMALE',
+      category: CATEGORIES[i % CATEGORIES.length],
+      currency: CURRENCIES[i % CURRENCIES.length],
+      products: [
+        {
+          product_name: PRODUCTS[i % PRODUCTS.length],
+          price,
+          quantity: qty,
+        },
+      ],
+      taxful_total_price: Math.round(price * qty * 1.2 * 100) / 100,
+      order_id: `${1000 + i}`,
+      geoip: {
+        location: {
+          lat: 33.0 + Math.random() * 20,
+          lon: -118.0 + Math.random() * 50,
+        },
+      },
+    });
+  }
+
+  return docs;
+}
+
+export const TEST_INDEX = 'test_ecommerce';
+
+export async function seedTestData(esUrl: string): Promise<void> {
+  console.log(`🌱 Seeding ${TEST_INDEX} index…`);
+
+  // Create index with explicit mappings
+  const mappings = {
+    mappings: {
+      properties: {
+        order_date: { type: 'date' },
+        customer_first_name: { type: 'keyword' },
+        customer_last_name: { type: 'keyword' },
+        customer_gender: { type: 'keyword' },
+        category: { type: 'keyword' },
+        currency: { type: 'keyword' },
+        order_id: { type: 'keyword' },
+        taxful_total_price: { type: 'double' },
+        products: {
+          type: 'nested',
+          properties: {
+            product_name: { type: 'text', fields: { keyword: { type: 'keyword' } } },
+            price: { type: 'double' },
+            quantity: { type: 'integer' },
+          },
+        },
+        geoip: {
+          properties: {
+            location: { type: 'geo_point' },
+          },
+        },
+      },
+    },
+  };
+
+  await fetch(`${esUrl}/${TEST_INDEX}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(mappings),
+  });
+
+  // Bulk index documents
+  const docs = generateDocs(20);
+  const bulkBody =
+    docs
+      .flatMap((doc, i) => [
+        JSON.stringify({ index: { _index: TEST_INDEX, _id: `${i}` } }),
+        JSON.stringify(doc),
+      ])
+      .join('\n') + '\n';
+
+  const bulkRes = await fetch(`${esUrl}/_bulk`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-ndjson' },
+    body: bulkBody,
+  });
+
+  if (!bulkRes.ok) {
+    throw new Error(`Bulk indexing failed: ${bulkRes.status} ${await bulkRes.text()}`);
+  }
+
+  // Refresh to make docs searchable
+  await fetch(`${esUrl}/${TEST_INDEX}/_refresh`, { method: 'POST' });
+
+  console.log(`✅ Seeded ${docs.length} documents into ${TEST_INDEX}`);
+}

--- a/server/src/integration-tests/setup/test-server.ts
+++ b/server/src/integration-tests/setup/test-server.ts
@@ -56,6 +56,9 @@ export class MCPTestServer {
         KIBANA_URL: process.env.KIBANA_URL!,
         // Isolate dashboard storage to a temp dir (never touches user dashboards)
         DASHBOARDS_DIR: this.dashboardsDir,
+        // Credentials for Kibana (security is disabled in test containers, but tools require them)
+        ES_USERNAME: 'elastic',
+        ES_PASSWORD: 'changeme',
         // Prevent the server from reading a local .env that could override test URLs
         NODE_ENV: 'test',
       },

--- a/server/src/integration-tests/setup/test-server.ts
+++ b/server/src/integration-tests/setup/test-server.ts
@@ -70,11 +70,15 @@ export class MCPTestServer {
     });
 
     const connectPromise = this.client.connect(this.transport);
-    const timeoutPromise = new Promise<never>((_, reject) =>
-      setTimeout(() => reject(new Error('MCP client connection timeout')), this.timeout)
-    );
-
-    await Promise.race([connectPromise, timeoutPromise]);
+    let timer: ReturnType<typeof setTimeout>;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => reject(new Error('MCP client connection timeout')), this.timeout);
+    });
+    try {
+      await Promise.race([connectPromise, timeoutPromise]);
+    } finally {
+      clearTimeout(timer!);
+    }
   }
 
   async stop(): Promise<void> {

--- a/server/src/integration-tests/setup/test-server.ts
+++ b/server/src/integration-tests/setup/test-server.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+/**
+ * MCP Test Server Harness
+ *
+ * Spawns the MCP server as a child process via StdioClientTransport,
+ * providing an isolated in-memory dashboard store per instance.
+ */
+
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type {
+  CallToolResult,
+  ListToolsResult,
+  ListResourcesResult,
+  ReadResourceResult,
+} from '@modelcontextprotocol/sdk/types.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SERVER_CWD = resolve(__dirname, '..', '..', '..');
+
+export class MCPTestServer {
+  private client: Client | null = null;
+  private transport: StdioClientTransport | null = null;
+  private timeout: number;
+
+  constructor(opts: { timeout?: number } = {}) {
+    this.timeout = opts.timeout ?? 30_000;
+  }
+
+  async start(): Promise<void> {
+    if (this.client) {
+      throw new Error('Test server already started. Call stop() first.');
+    }
+
+    this.transport = new StdioClientTransport({
+      command: 'node',
+      args: ['--import', 'tsx', 'src/index.ts'],
+      cwd: SERVER_CWD,
+      env: {
+        ...process.env,
+        // Forward container URLs set by global setup
+        ES_NODE: process.env.ES_NODE!,
+        KIBANA_URL: process.env.KIBANA_URL!,
+        // Prevent the server from reading a local .env that could override test URLs
+        NODE_ENV: 'test',
+      },
+    });
+
+    this.client = new Client({
+      name: 'integration-test-client',
+      version: '1.0.0',
+    });
+
+    const connectPromise = this.client.connect(this.transport);
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('MCP client connection timeout')), this.timeout)
+    );
+
+    await Promise.race([connectPromise, timeoutPromise]);
+  }
+
+  async stop(): Promise<void> {
+    if (this.client) {
+      try {
+        await this.client.close();
+      } catch {
+        // Ignore close errors — process may have already exited
+      }
+      this.client = null;
+    }
+    this.transport = null;
+  }
+
+  // ── Tool helpers ──────────────────────────────────────────────
+
+  async callTool(name: string, args: Record<string, unknown> = {}): Promise<CallToolResult> {
+    return this.getClient().callTool({ name, arguments: args }) as Promise<CallToolResult>;
+  }
+
+  async listTools(): Promise<ListToolsResult> {
+    return this.getClient().listTools();
+  }
+
+  // ── Resource helpers ──────────────────────────────────────────
+
+  async listResources(): Promise<ListResourcesResult> {
+    return this.getClient().listResources();
+  }
+
+  async readResource(uri: string): Promise<ReadResourceResult> {
+    return this.getClient().readResource({ uri });
+  }
+
+  // ── Internal ──────────────────────────────────────────────────
+
+  private getClient(): Client {
+    if (!this.client) {
+      throw new Error('Test server not started. Call start() first.');
+    }
+    return this.client;
+  }
+}

--- a/server/src/integration-tests/setup/test-server.ts
+++ b/server/src/integration-tests/setup/test-server.ts
@@ -56,9 +56,9 @@ export class MCPTestServer {
         KIBANA_URL: process.env.KIBANA_URL!,
         // Isolate dashboard storage to a temp dir (never touches user dashboards)
         DASHBOARDS_DIR: this.dashboardsDir,
-        // Credentials for Kibana (security is disabled in test containers, but tools require them)
-        ES_USERNAME: 'elastic',
-        ES_PASSWORD: 'changeme',
+        // Forward credentials set by global setup (security enabled in containers)
+        ES_USERNAME: process.env.ES_USERNAME!,
+        ES_PASSWORD: process.env.ES_PASSWORD!,
         // Prevent the server from reading a local .env that could override test URLs
         NODE_ENV: 'test',
       },

--- a/server/src/integration-tests/setup/test-server.ts
+++ b/server/src/integration-tests/setup/test-server.ts
@@ -11,7 +11,9 @@
  * providing an isolated in-memory dashboard store per instance.
  */
 
+import { mkdtempSync } from 'fs';
 import { resolve, dirname } from 'path';
+import { tmpdir } from 'os';
 import { fileURLToPath } from 'url';
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -30,9 +32,12 @@ export class MCPTestServer {
   private client: Client | null = null;
   private transport: StdioClientTransport | null = null;
   private timeout: number;
+  private dashboardsDir: string;
 
   constructor(opts: { timeout?: number } = {}) {
     this.timeout = opts.timeout ?? 30_000;
+    // Each instance gets its own temp dir — tests never touch user dashboards
+    this.dashboardsDir = mkdtempSync(resolve(tmpdir(), 'mcp-test-dashboards-'));
   }
 
   async start(): Promise<void> {
@@ -49,6 +54,8 @@ export class MCPTestServer {
         // Forward container URLs set by global setup
         ES_NODE: process.env.ES_NODE!,
         KIBANA_URL: process.env.KIBANA_URL!,
+        // Isolate dashboard storage to a temp dir (never touches user dashboards)
+        DASHBOARDS_DIR: this.dashboardsDir,
         // Prevent the server from reading a local .env that could override test URLs
         NODE_ENV: 'test',
       },

--- a/server/src/integration-tests/suites/_smoke.test.ts
+++ b/server/src/integration-tests/suites/_smoke.test.ts
@@ -4,9 +4,10 @@
  * you may not use this file except in compliance with the Elastic License 2.0.
  */
 
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 
 import { TEST_INDEX } from '../setup/seed-data.js';
+import { MCPTestServer } from '../setup/test-server.js';
 
 describe('Smoke test: containers and seed data', () => {
   it('should have ES_NODE set by global setup', () => {
@@ -38,5 +39,35 @@ describe('Smoke test: containers and seed data', () => {
   it('Kibana should be reachable', async () => {
     const res = await fetch(`${process.env.KIBANA_URL}/api/status`);
     expect(res.status).toBe(200);
+  });
+});
+
+describe('Smoke test: MCPTestServer harness', () => {
+  let server: MCPTestServer;
+
+  beforeEach(async () => {
+    server = new MCPTestServer();
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('should connect and list tools', async () => {
+    const result = await server.listTools();
+    expect(result.tools.length).toBeGreaterThan(0);
+    const toolNames = result.tools.map((t) => t.name);
+    expect(toolNames).toContain('run_esql');
+    expect(toolNames).toContain('list_indices');
+    expect(toolNames).toContain('create_chart');
+  });
+
+  it('should list resources', async () => {
+    const result = await server.listResources();
+    expect(result.resources.length).toBeGreaterThan(0);
+    const uris = result.resources.map((r) => r.uri);
+    expect(uris).toContain('dataviz://guidelines');
+    expect(uris).toContain('esql://reference');
   });
 });

--- a/server/src/integration-tests/suites/_smoke.test.ts
+++ b/server/src/integration-tests/suites/_smoke.test.ts
@@ -9,6 +9,12 @@ import { afterEach, beforeEach, describe, it, expect } from 'vitest';
 import { TEST_INDEX } from '../setup/seed-data.js';
 import { MCPTestServer } from '../setup/test-server.js';
 
+function authHeader(): Record<string, string> {
+  return {
+    Authorization: `Basic ${Buffer.from(`${process.env.ES_USERNAME}:${process.env.ES_PASSWORD}`).toString('base64')}`,
+  };
+}
+
 describe('Smoke test: containers and seed data', () => {
   it('should have ES_NODE set by global setup', () => {
     expect(process.env.ES_NODE).toBeDefined();
@@ -21,13 +27,17 @@ describe('Smoke test: containers and seed data', () => {
   });
 
   it('should have seeded test data in Elasticsearch', async () => {
-    const res = await fetch(`${process.env.ES_NODE}/${TEST_INDEX}/_count`);
+    const res = await fetch(`${process.env.ES_NODE}/${TEST_INDEX}/_count`, {
+      headers: authHeader(),
+    });
     const body = await res.json();
     expect(body.count).toBe(20);
   });
 
   it('should have correct field mappings', async () => {
-    const res = await fetch(`${process.env.ES_NODE}/${TEST_INDEX}/_mapping`);
+    const res = await fetch(`${process.env.ES_NODE}/${TEST_INDEX}/_mapping`, {
+      headers: authHeader(),
+    });
     const body = await res.json();
     const props = body[TEST_INDEX].mappings.properties;
     expect(props.order_date.type).toBe('date');
@@ -37,7 +47,7 @@ describe('Smoke test: containers and seed data', () => {
   });
 
   it('Kibana should be reachable', async () => {
-    const res = await fetch(`${process.env.KIBANA_URL}/api/status`);
+    const res = await fetch(`${process.env.KIBANA_URL}/api/status`, { headers: authHeader() });
     expect(res.status).toBe(200);
   });
 });

--- a/server/src/integration-tests/suites/_smoke.test.ts
+++ b/server/src/integration-tests/suites/_smoke.test.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { TEST_INDEX } from '../setup/seed-data.js';
+
+describe('Smoke test: containers and seed data', () => {
+  it('should have ES_NODE set by global setup', () => {
+    expect(process.env.ES_NODE).toBeDefined();
+    expect(process.env.ES_NODE).toMatch(/^http/);
+  });
+
+  it('should have KIBANA_URL set by global setup', () => {
+    expect(process.env.KIBANA_URL).toBeDefined();
+    expect(process.env.KIBANA_URL).toMatch(/^http/);
+  });
+
+  it('should have seeded test data in Elasticsearch', async () => {
+    const res = await fetch(`${process.env.ES_NODE}/${TEST_INDEX}/_count`);
+    const body = await res.json();
+    expect(body.count).toBe(20);
+  });
+
+  it('should have correct field mappings', async () => {
+    const res = await fetch(`${process.env.ES_NODE}/${TEST_INDEX}/_mapping`);
+    const body = await res.json();
+    const props = body[TEST_INDEX].mappings.properties;
+    expect(props.order_date.type).toBe('date');
+    expect(props.category.type).toBe('keyword');
+    expect(props.taxful_total_price.type).toBe('double');
+    expect(props.geoip.properties.location.type).toBe('geo_point');
+  });
+
+  it('Kibana should be reachable', async () => {
+    const res = await fetch(`${process.env.KIBANA_URL}/api/status`);
+    expect(res.status).toBe(200);
+  });
+});

--- a/server/src/integration-tests/suites/_smoke.test.ts
+++ b/server/src/integration-tests/suites/_smoke.test.ts
@@ -4,10 +4,9 @@
  * you may not use this file except in compliance with the Elastic License 2.0.
  */
 
-import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 import { TEST_INDEX } from '../setup/seed-data.js';
-import { MCPTestServer } from '../setup/test-server.js';
 
 function authHeader(): Record<string, string> {
   return {
@@ -49,35 +48,5 @@ describe('Smoke test: containers and seed data', () => {
   it('Kibana should be reachable', async () => {
     const res = await fetch(`${process.env.KIBANA_URL}/api/status`, { headers: authHeader() });
     expect(res.status).toBe(200);
-  });
-});
-
-describe('Smoke test: MCPTestServer harness', () => {
-  let server: MCPTestServer;
-
-  beforeEach(async () => {
-    server = new MCPTestServer();
-    await server.start();
-  });
-
-  afterEach(async () => {
-    await server.stop();
-  });
-
-  it('should connect and list tools', async () => {
-    const result = await server.listTools();
-    expect(result.tools.length).toBeGreaterThan(0);
-    const toolNames = result.tools.map((t) => t.name);
-    expect(toolNames).toContain('run_esql');
-    expect(toolNames).toContain('list_indices');
-    expect(toolNames).toContain('create_chart');
-  });
-
-  it('should list resources', async () => {
-    const result = await server.listResources();
-    expect(result.resources.length).toBeGreaterThan(0);
-    const uris = result.resources.map((r) => r.uri);
-    expect(uris).toContain('dataviz://guidelines');
-    expect(uris).toContain('esql://reference');
   });
 });

--- a/server/src/integration-tests/suites/chart-lifecycle.test.ts
+++ b/server/src/integration-tests/suites/chart-lifecycle.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  SAMPLE_BAR_CHART_ARGS,
+  SAMPLE_LINE_CHART_ARGS,
+} from '../__fixtures__/dashboard-factory.js';
+import { expectSuccess, expectTextContent } from '../helpers/mcp-assertions.js';
+import { MCPTestServer } from '../setup/test-server.js';
+
+describe('Chart lifecycle', () => {
+  let server: MCPTestServer;
+
+  beforeEach(async () => {
+    server = new MCPTestServer();
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('should create a dashboard and return its ID', async () => {
+    const result = await server.callTool('create_dashboard', {
+      title: 'Test Dashboard',
+    });
+    const text = expectSuccess(result);
+    expect(text).toContain('Test Dashboard');
+    expect(text).toContain('created');
+  });
+
+  it('should create a bar chart on a dashboard', async () => {
+    // Create dashboard first
+    await server.callTool('create_dashboard', { title: 'Chart Test' });
+
+    // Create chart
+    const result = await server.callTool('create_chart', SAMPLE_BAR_CHART_ARGS);
+    const text = expectSuccess(result);
+    expect(text).toContain('Revenue by Category');
+  });
+
+  it('should create a line chart on a dashboard', async () => {
+    await server.callTool('create_dashboard', { title: 'Line Chart Test' });
+
+    const result = await server.callTool('create_chart', SAMPLE_LINE_CHART_ARGS);
+    const text = expectSuccess(result);
+    expect(text).toContain('Orders Over Time');
+  });
+
+  it('should view a dashboard with its charts', async () => {
+    await server.callTool('create_dashboard', { title: 'View Test' });
+    await server.callTool('create_chart', SAMPLE_BAR_CHART_ARGS);
+
+    // view_dashboard returns a summary; get_dashboard returns full config
+    const viewResult = await server.callTool('view_dashboard');
+    const viewText = expectSuccess(viewResult);
+    expect(viewText).toContain('View Test');
+    expect(viewText).toContain('1 chart');
+
+    const getResult = await server.callTool('get_dashboard');
+    const getText = expectSuccess(getResult);
+    expect(getText).toContain('Revenue by Category');
+  });
+
+  it('should create multiple charts on one dashboard', async () => {
+    await server.callTool('create_dashboard', { title: 'Multi Chart' });
+    await server.callTool('create_chart', SAMPLE_BAR_CHART_ARGS);
+    await server.callTool('create_chart', SAMPLE_LINE_CHART_ARGS);
+
+    const getResult = await server.callTool('get_dashboard');
+    const text = expectSuccess(getResult);
+    expect(text).toContain('Revenue by Category');
+    expect(text).toContain('Orders Over Time');
+  });
+
+  it('should remove a chart from the dashboard', async () => {
+    await server.callTool('create_dashboard', { title: 'Remove Test' });
+    const chartResult = await server.callTool('create_chart', {
+      ...SAMPLE_BAR_CHART_ARGS,
+      id: 'chart-to-remove',
+    });
+    expectSuccess(chartResult);
+
+    const removeResult = await server.callTool('remove_chart', { chartId: 'chart-to-remove' });
+    expectSuccess(removeResult);
+
+    const viewResult = await server.callTool('view_dashboard');
+    const text = expectTextContent(viewResult);
+    expect(text).not.toContain('Revenue by Category');
+  });
+
+  it('should handle chart creation with invalid ES|QL gracefully', async () => {
+    await server.callTool('create_dashboard', { title: 'Error Test' });
+
+    const result = await server.callTool('create_chart', {
+      ...SAMPLE_BAR_CHART_ARGS,
+      esqlQuery: 'INVALID SYNTAX',
+    });
+    const text = expectTextContent(result);
+    // Should return an error message, not crash
+    expect(text.toLowerCase()).toMatch(/error|failed|invalid|parse/);
+  });
+});

--- a/server/src/integration-tests/suites/dashboard-management.test.ts
+++ b/server/src/integration-tests/suites/dashboard-management.test.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { expectSuccess, expectTextContent } from '../helpers/mcp-assertions.js';
+import { MCPTestServer } from '../setup/test-server.js';
+
+describe('Dashboard management', () => {
+  let server: MCPTestServer;
+
+  beforeEach(async () => {
+    server = new MCPTestServer();
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('should list dashboards', async () => {
+    await server.callTool('create_dashboard', { title: 'Dashboard A' });
+    await server.callTool('create_dashboard', { title: 'Dashboard B' });
+
+    const result = await server.callTool('list_dashboards');
+    const text = expectSuccess(result);
+    expect(text).toContain('Dashboard A');
+    expect(text).toContain('Dashboard B');
+  });
+
+  it('should rename a dashboard', async () => {
+    await server.callTool('create_dashboard', { title: 'Old Title' });
+
+    const result = await server.callTool('set_dashboard_title', { title: 'New Title' });
+    const text = expectSuccess(result);
+    expect(text).toContain('New Title');
+  });
+
+  it('should switch between dashboards', async () => {
+    const createA = await server.callTool('create_dashboard', { title: 'Dash A', id: 'dash-a' });
+    expectSuccess(createA);
+
+    await server.callTool('create_dashboard', { title: 'Dash B', id: 'dash-b' });
+
+    // Switch back to A
+    const switchResult = await server.callTool('switch_dashboard', { id: 'dash-a' });
+    const text = expectSuccess(switchResult);
+    expect(text).toContain('Dash A');
+  });
+
+  it('should delete a dashboard', async () => {
+    await server.callTool('create_dashboard', { title: 'Keep', id: 'keep' });
+    await server.callTool('create_dashboard', { title: 'Delete Me', id: 'delete-me' });
+
+    const result = await server.callTool('delete_dashboard', { id: 'delete-me' });
+    const text = expectSuccess(result);
+    expect(text.toLowerCase()).toContain('delete');
+
+    // Verify it's gone
+    const listResult = await server.callTool('list_dashboards');
+    const listText = expectTextContent(listResult);
+    expect(listText).not.toContain('Delete Me');
+  });
+
+  it('should clear a dashboard', async () => {
+    await server.callTool('create_dashboard', { title: 'Clear Test' });
+
+    const result = await server.callTool('clear_dashboard');
+    const text = expectSuccess(result);
+    expect(text.toLowerCase()).toContain('clear');
+  });
+});

--- a/server/src/integration-tests/suites/esql-tools.test.ts
+++ b/server/src/integration-tests/suites/esql-tools.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { TEST_INDEX } from '../setup/seed-data.js';
+import { expectSuccess, expectTextContent } from '../helpers/mcp-assertions.js';
+import { MCPTestServer } from '../setup/test-server.js';
+
+describe('ES|QL tools', () => {
+  let server: MCPTestServer;
+
+  beforeEach(async () => {
+    server = new MCPTestServer();
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  describe('list_indices', () => {
+    it('should return the seeded test index', async () => {
+      const result = await server.callTool('list_indices');
+      const text = expectSuccess(result);
+      expect(text).toContain(TEST_INDEX);
+    });
+  });
+
+  describe('run_esql', () => {
+    it('should execute a valid query and return results', async () => {
+      const result = await server.callTool('run_esql', {
+        query: `FROM ${TEST_INDEX} | STATS count = COUNT(*)`,
+      });
+      const text = expectSuccess(result);
+      // Should contain the count of 20 seeded documents
+      expect(text).toContain('20');
+    });
+
+    it('should return tabular data for aggregations', async () => {
+      const result = await server.callTool('run_esql', {
+        query: `FROM ${TEST_INDEX} | STATS revenue = SUM(taxful_total_price) BY category | SORT category`,
+      });
+      const text = expectSuccess(result);
+      // Should contain category names from seed data
+      expect(text).toContain("Men's Clothing");
+    });
+
+    it('should handle queries with LIMIT', async () => {
+      const result = await server.callTool('run_esql', {
+        query: `FROM ${TEST_INDEX} | LIMIT 5`,
+      });
+      const text = expectSuccess(result);
+      // Should return data (field names from seed data)
+      expect(text).toContain('customer_first_name');
+    });
+
+    it('should return an error for invalid queries', async () => {
+      const result = await server.callTool('run_esql', {
+        query: 'INVALID QUERY SYNTAX',
+      });
+      const text = expectTextContent(result);
+      // Should contain error information rather than crashing
+      expect(text.toLowerCase()).toMatch(/error|failed|invalid|parse/);
+    });
+
+    it('should return an error for non-existent indices', async () => {
+      const result = await server.callTool('run_esql', {
+        query: 'FROM nonexistent_index_xyz_999 | STATS count = COUNT(*)',
+      });
+      const text = expectTextContent(result);
+      expect(text.toLowerCase()).toMatch(/error|unknown|not found|no such/);
+    });
+  });
+});

--- a/server/src/integration-tests/suites/kibana-roundtrip.test.ts
+++ b/server/src/integration-tests/suites/kibana-roundtrip.test.ts
@@ -11,17 +11,53 @@
  *   - Kibana <  9.4  →  saved objects API  (hasDashboardApi = false)
  *   - Kibana >= 9.4  →  Dashboard API      (hasDashboardApi = true)
  *
+ * Modelled after the unit-level roundtrip tests in:
+ *   - lens-roundtrip.test.ts       (saved objects / Lens path)
+ *   - dashboard-api-roundtrip.test.ts (Dashboard API path)
+ *
  * The same tests run against both 9.3 and 9.4 via STACK_VERSION env var.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import {
-  SAMPLE_BAR_CHART_ARGS,
-  SAMPLE_LINE_CHART_ARGS,
-} from '../__fixtures__/dashboard-factory.js';
-import { expectSuccess, expectTextContent } from '../helpers/mcp-assertions.js';
+import { TEST_INDEX } from '../setup/seed-data.js';
+import { expectSuccess, expectTextContent, parseJsonContent } from '../helpers/mcp-assertions.js';
 import { MCPTestServer } from '../setup/test-server.js';
+
+/** Extract the Kibana dashboard ID from an export response URL */
+function extractDashboardId(exportText: string): string | null {
+  const match = exportText.match(/#\/view\/([^\s"'\n]+)/);
+  return match ? match[1] : null;
+}
+
+/** Get the full dashboard config via get_dashboard */
+async function getDashboardConfig(server: MCPTestServer, dashboardId?: string) {
+  const result = await server.callTool('get_dashboard', dashboardId ? { dashboardId } : {});
+  return parseJsonContent(result) as {
+    title: string;
+    charts: Array<{
+      id: string;
+      title: string;
+      chartType: string;
+      esqlQuery: string;
+      xField?: string;
+      yFields?: string[];
+      splitField?: string;
+      palette?: string[];
+      valueField?: string;
+      yField?: string;
+      subtitle?: string;
+      color?: string;
+      colorRamp?: string[];
+    }>;
+    sections: Array<{
+      id: string;
+      title: string;
+      collapsed: boolean;
+      panelIds: string[];
+    }>;
+  };
+}
 
 describe('Kibana roundtrip', () => {
   let server: MCPTestServer;
@@ -35,75 +71,295 @@ describe('Kibana roundtrip', () => {
     await server.stop();
   });
 
-  it('should export a dashboard with a single chart to Kibana', async () => {
-    await server.callTool('create_dashboard', { title: 'Export Test Single' });
-    await server.callTool('create_chart', SAMPLE_BAR_CHART_ARGS);
+  // ---------------------------------------------------------------------------
+  // Basic export/import
+  // ---------------------------------------------------------------------------
 
-    const result = await server.callTool('export_to_kibana');
-    const text = expectSuccess(result);
-    // Should contain a Kibana URL or dashboard ID
-    expect(text.toLowerCase()).toMatch(/dashboard|exported|kibana|created/);
-  });
-
-  it('should export a dashboard with multiple charts to Kibana', async () => {
-    await server.callTool('create_dashboard', { title: 'Export Test Multi' });
-    await server.callTool('create_chart', SAMPLE_BAR_CHART_ARGS);
-    await server.callTool('create_chart', SAMPLE_LINE_CHART_ARGS);
-
-    const result = await server.callTool('export_to_kibana');
-    const text = expectSuccess(result);
-    expect(text.toLowerCase()).toMatch(/dashboard|exported|kibana|created/);
-  });
-
-  it('should export with a title override', async () => {
-    await server.callTool('create_dashboard', { title: 'Original Title' });
-    await server.callTool('create_chart', SAMPLE_BAR_CHART_ARGS);
-
-    const result = await server.callTool('export_to_kibana', {
-      title: 'Overridden Title',
+  it('should export a dashboard to Kibana', async () => {
+    await server.callTool('create_dashboard', { title: 'Export Test' });
+    await server.callTool('create_chart', {
+      title: 'Revenue',
+      chartType: 'bar',
+      esqlQuery: `FROM ${TEST_INDEX} | STATS revenue = SUM(taxful_total_price) BY category`,
+      xField: 'category',
+      yFields: ['revenue'],
     });
+
+    const result = await server.callTool('export_to_kibana');
     const text = expectSuccess(result);
-    expect(text.toLowerCase()).toMatch(/dashboard|exported|kibana|created/);
+    expect(text).toContain('exported');
+    expect(extractDashboardId(text)).not.toBeNull();
   });
 
   it('should fail to export an empty dashboard', async () => {
-    await server.callTool('create_dashboard', { title: 'Empty Dashboard' });
-
+    await server.callTool('create_dashboard', { title: 'Empty' });
     const result = await server.callTool('export_to_kibana');
-    const text = expectTextContent(result);
     expect(result.isError).toBe(true);
-    expect(text.toLowerCase()).toContain('no charts');
+    expect(expectTextContent(result).toLowerCase()).toContain('no charts');
   });
 
-  it('should roundtrip: export then import preserves charts', async () => {
-    // Create and populate a dashboard
-    await server.callTool('create_dashboard', { title: 'Roundtrip Test' });
+  // ---------------------------------------------------------------------------
+  // Chart config roundtrip — verify settings survive export → import
+  // ---------------------------------------------------------------------------
+
+  it('bar chart config survives roundtrip', async () => {
+    await server.callTool('create_dashboard', { title: 'Bar Roundtrip' });
     await server.callTool('create_chart', {
-      ...SAMPLE_BAR_CHART_ARGS,
-      id: 'roundtrip-bar',
+      id: 'bar-rt',
+      title: 'Revenue by Category',
+      chartType: 'bar',
+      esqlQuery: `FROM ${TEST_INDEX} | STATS revenue = SUM(taxful_total_price) BY category`,
+      xField: 'category',
+      yFields: ['revenue'],
     });
 
-    // Export to Kibana
     const exportResult = await server.callTool('export_to_kibana');
-    const exportText = expectSuccess(exportResult);
+    const kibanaDashId = extractDashboardId(expectSuccess(exportResult));
+    expect(kibanaDashId).not.toBeNull();
 
-    // Extract the dashboard ID from the URL in the export response
-    // URL format: http://localhost:55026/app/dashboards#/view/<id>
-    const urlMatch = exportText.match(/#\/view\/([^\s"'\n]+)/);
-
-    if (!urlMatch) {
-      // If we can't extract an ID, just verify the export succeeded
-      expect(exportText.toLowerCase()).toMatch(/dashboard|exported|kibana|created/);
-      return;
-    }
-
-    const kibanaDashboardId = urlMatch[1];
-
-    // Import from Kibana into a fresh dashboard
     const importResult = await server.callTool('import_from_kibana', {
-      dashboardId: kibanaDashboardId,
+      dashboardId: kibanaDashId!,
     });
-    const importText = expectSuccess(importResult);
-    expect(importText.toLowerCase()).toMatch(/import|dashboard|created/);
+    expectSuccess(importResult);
+
+    const config = await getDashboardConfig(server);
+    const chart = config.charts.find((c) => c.chartType === 'bar');
+    expect(chart).toBeDefined();
+    expect(chart!.title).toBe('Revenue by Category');
+    expect(chart!.esqlQuery).toContain(TEST_INDEX);
+    expect(chart!.esqlQuery).toContain('SUM(taxful_total_price)');
+    expect(chart!.xField).toBe('category');
+    expect(chart!.yFields).toEqual(['revenue']);
+  });
+
+  it('line chart config survives roundtrip', async () => {
+    await server.callTool('create_dashboard', { title: 'Line Roundtrip' });
+    await server.callTool('create_chart', {
+      id: 'line-rt',
+      title: 'Orders Over Time',
+      chartType: 'line',
+      esqlQuery: `FROM ${TEST_INDEX} | STATS orders = COUNT(*) BY order_date = BUCKET(order_date, 1 day)`,
+      xField: 'order_date',
+      yFields: ['orders'],
+    });
+
+    const exportResult = await server.callTool('export_to_kibana');
+    const kibanaDashId = extractDashboardId(expectSuccess(exportResult));
+    expect(kibanaDashId).not.toBeNull();
+
+    await server.callTool('import_from_kibana', { dashboardId: kibanaDashId! });
+
+    const config = await getDashboardConfig(server);
+    const chart = config.charts.find((c) => c.chartType === 'line');
+    expect(chart).toBeDefined();
+    expect(chart!.title).toBe('Orders Over Time');
+    expect(chart!.xField).toBe('order_date');
+    expect(chart!.yFields).toEqual(['orders']);
+  });
+
+  it('pie chart with palette survives roundtrip', async () => {
+    await server.callTool('create_dashboard', { title: 'Pie Roundtrip' });
+    await server.callTool('create_chart', {
+      id: 'pie-rt',
+      title: 'Category Share',
+      chartType: 'pie',
+      esqlQuery: `FROM ${TEST_INDEX} | STATS count = COUNT(*) BY category`,
+      xField: 'category',
+      yFields: ['count'],
+      palette: ['#E91E63', '#54B399', '#D6BF57', '#6092C0'],
+    });
+
+    const exportResult = await server.callTool('export_to_kibana');
+    const kibanaDashId = extractDashboardId(expectSuccess(exportResult));
+    expect(kibanaDashId).not.toBeNull();
+
+    await server.callTool('import_from_kibana', { dashboardId: kibanaDashId! });
+
+    const config = await getDashboardConfig(server);
+    const chart = config.charts.find((c) => c.chartType === 'pie');
+    expect(chart).toBeDefined();
+    expect(chart!.title).toBe('Category Share');
+    expect(chart!.xField).toBe('category');
+    expect(chart!.yFields).toEqual(['count']);
+    expect(chart!.palette).toEqual(['#E91E63', '#54B399', '#D6BF57', '#6092C0']);
+  });
+
+  it('metric config survives roundtrip', async () => {
+    await server.callTool('create_dashboard', { title: 'Metric Roundtrip' });
+    await server.callTool('create_metric', {
+      id: 'metric-rt',
+      title: 'Total Revenue',
+      esqlQuery: `FROM ${TEST_INDEX} | STATS total = SUM(taxful_total_price)`,
+      valueField: 'total',
+      subtitle: 'All orders',
+      color: '#54B399',
+    });
+
+    const exportResult = await server.callTool('export_to_kibana');
+    const kibanaDashId = extractDashboardId(expectSuccess(exportResult));
+    expect(kibanaDashId).not.toBeNull();
+
+    await server.callTool('import_from_kibana', { dashboardId: kibanaDashId! });
+
+    const config = await getDashboardConfig(server);
+    const metric = config.charts.find((c) => c.chartType === 'metric');
+    expect(metric).toBeDefined();
+    expect(metric!.title).toBe('Total Revenue');
+    expect(metric!.valueField).toBe('total');
+    expect(metric!.subtitle).toBe('All orders');
+    expect(metric!.color).toBe('#54B399');
+  });
+
+  it('heatmap config survives roundtrip', async () => {
+    await server.callTool('create_dashboard', { title: 'Heatmap Roundtrip' });
+    await server.callTool('create_heatmap', {
+      id: 'heatmap-rt',
+      title: 'Category by Gender',
+      esqlQuery: `FROM ${TEST_INDEX} | STATS count = COUNT(*) BY category, customer_gender`,
+      xField: 'category',
+      yField: 'customer_gender',
+      valueField: 'count',
+    });
+
+    const exportResult = await server.callTool('export_to_kibana');
+    const kibanaDashId = extractDashboardId(expectSuccess(exportResult));
+    expect(kibanaDashId).not.toBeNull();
+
+    await server.callTool('import_from_kibana', { dashboardId: kibanaDashId! });
+
+    const config = await getDashboardConfig(server);
+    const heatmap = config.charts.find((c) => c.chartType === 'heatmap');
+    expect(heatmap).toBeDefined();
+    expect(heatmap!.title).toBe('Category by Gender');
+    expect(heatmap!.xField).toBe('category');
+    expect(heatmap!.yField).toBe('customer_gender');
+    expect(heatmap!.valueField).toBe('count');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Multi-chart + sections roundtrip
+  // ---------------------------------------------------------------------------
+
+  it('multiple charts and sections survive roundtrip', async () => {
+    await server.callTool('create_dashboard', { title: 'Full Roundtrip' });
+
+    // Create charts
+    await server.callTool('create_metric', {
+      id: 'kpi-revenue',
+      title: 'Total Revenue',
+      esqlQuery: `FROM ${TEST_INDEX} | STATS total = SUM(taxful_total_price)`,
+      valueField: 'total',
+    });
+    await server.callTool('create_chart', {
+      id: 'bar-by-cat',
+      title: 'Revenue by Category',
+      chartType: 'bar',
+      esqlQuery: `FROM ${TEST_INDEX} | STATS revenue = SUM(taxful_total_price) BY category`,
+      xField: 'category',
+      yFields: ['revenue'],
+    });
+    await server.callTool('create_chart', {
+      id: 'line-orders',
+      title: 'Orders Over Time',
+      chartType: 'line',
+      esqlQuery: `FROM ${TEST_INDEX} | STATS orders = COUNT(*) BY order_date = BUCKET(order_date, 1 day)`,
+      xField: 'order_date',
+      yFields: ['orders'],
+    });
+
+    // Create sections and assign panels
+    await server.callTool('create_section', {
+      id: 'kpi-section',
+      title: 'KPIs',
+      panelIds: ['kpi-revenue'],
+    });
+    await server.callTool('create_section', {
+      id: 'charts-section',
+      title: 'Charts',
+      panelIds: ['bar-by-cat', 'line-orders'],
+    });
+
+    // Snapshot before export
+    const beforeConfig = await getDashboardConfig(server);
+    expect(beforeConfig.charts).toHaveLength(3);
+    expect(beforeConfig.sections).toHaveLength(2);
+
+    // Export
+    const exportResult = await server.callTool('export_to_kibana');
+    const kibanaDashId = extractDashboardId(expectSuccess(exportResult));
+    expect(kibanaDashId).not.toBeNull();
+
+    // Import into fresh dashboard
+    const importResult = await server.callTool('import_from_kibana', {
+      dashboardId: kibanaDashId!,
+    });
+    expectSuccess(importResult);
+
+    const afterConfig = await getDashboardConfig(server);
+
+    // Verify all 3 charts survived
+    expect(afterConfig.charts.length).toBeGreaterThanOrEqual(3);
+
+    const chartTypes = afterConfig.charts.map((c) => c.chartType).sort();
+    expect(chartTypes).toContain('bar');
+    expect(chartTypes).toContain('line');
+    expect(chartTypes).toContain('metric');
+
+    // Verify chart details
+    const bar = afterConfig.charts.find((c) => c.chartType === 'bar');
+    expect(bar!.title).toBe('Revenue by Category');
+    expect(bar!.xField).toBe('category');
+
+    const line = afterConfig.charts.find((c) => c.chartType === 'line');
+    expect(line!.title).toBe('Orders Over Time');
+
+    const metric = afterConfig.charts.find((c) => c.chartType === 'metric');
+    expect(metric!.title).toBe('Total Revenue');
+
+    // Verify sections survived with correct panel assignments
+    if (afterConfig.sections.length >= 2) {
+      const kpiSection = afterConfig.sections.find((s) => s.title === 'KPIs');
+      const chartsSection = afterConfig.sections.find((s) => s.title === 'Charts');
+
+      expect(kpiSection).toBeDefined();
+      expect(chartsSection).toBeDefined();
+
+      if (kpiSection && chartsSection) {
+        // Section order: KPIs before Charts
+        const kpiIdx = afterConfig.sections.indexOf(kpiSection);
+        const chartsIdx = afterConfig.sections.indexOf(chartsSection);
+        expect(kpiIdx).toBeLessThan(chartsIdx);
+
+        // KPI section should contain the metric
+        expect(kpiSection.panelIds.length).toBeGreaterThanOrEqual(1);
+
+        // Charts section should contain the bar and line
+        expect(chartsSection.panelIds.length).toBeGreaterThanOrEqual(2);
+      }
+    }
+  });
+
+  it('bar chart with splitField survives roundtrip', async () => {
+    await server.callTool('create_dashboard', { title: 'Split Roundtrip' });
+    await server.callTool('create_chart', {
+      id: 'split-rt',
+      title: 'Revenue by Category and Gender',
+      chartType: 'bar',
+      esqlQuery: `FROM ${TEST_INDEX} | STATS revenue = SUM(taxful_total_price) BY category, customer_gender`,
+      xField: 'category',
+      yFields: ['revenue'],
+      splitField: 'customer_gender',
+    });
+
+    const exportResult = await server.callTool('export_to_kibana');
+    const kibanaDashId = extractDashboardId(expectSuccess(exportResult));
+    expect(kibanaDashId).not.toBeNull();
+
+    await server.callTool('import_from_kibana', { dashboardId: kibanaDashId! });
+
+    const config = await getDashboardConfig(server);
+    const chart = config.charts.find((c) => c.chartType === 'bar');
+    expect(chart).toBeDefined();
+    expect(chart!.splitField).toBe('customer_gender');
   });
 });

--- a/server/src/integration-tests/suites/kibana-roundtrip.test.ts
+++ b/server/src/integration-tests/suites/kibana-roundtrip.test.ts
@@ -317,26 +317,24 @@ describe('Kibana roundtrip', () => {
     expect(metric!.title).toBe('Total Revenue');
 
     // Verify sections survived with correct panel assignments
-    if (afterConfig.sections.length >= 2) {
-      const kpiSection = afterConfig.sections.find((s) => s.title === 'KPIs');
-      const chartsSection = afterConfig.sections.find((s) => s.title === 'Charts');
+    expect(afterConfig.sections).toHaveLength(2);
 
-      expect(kpiSection).toBeDefined();
-      expect(chartsSection).toBeDefined();
+    const kpiSection = afterConfig.sections.find((s) => s.title === 'KPIs');
+    const chartsSection = afterConfig.sections.find((s) => s.title === 'Charts');
 
-      if (kpiSection && chartsSection) {
-        // Section order: KPIs before Charts
-        const kpiIdx = afterConfig.sections.indexOf(kpiSection);
-        const chartsIdx = afterConfig.sections.indexOf(chartsSection);
-        expect(kpiIdx).toBeLessThan(chartsIdx);
+    expect(kpiSection).toBeDefined();
+    expect(chartsSection).toBeDefined();
 
-        // KPI section should contain the metric
-        expect(kpiSection.panelIds.length).toBeGreaterThanOrEqual(1);
+    // Section order: KPIs before Charts
+    const kpiIdx = afterConfig.sections.indexOf(kpiSection!);
+    const chartsIdx = afterConfig.sections.indexOf(chartsSection!);
+    expect(kpiIdx).toBeLessThan(chartsIdx);
 
-        // Charts section should contain the bar and line
-        expect(chartsSection.panelIds.length).toBeGreaterThanOrEqual(2);
-      }
-    }
+    // KPI section should contain the metric
+    expect(kpiSection!.panelIds.length).toBeGreaterThanOrEqual(1);
+
+    // Charts section should contain the bar and line
+    expect(chartsSection!.panelIds.length).toBeGreaterThanOrEqual(2);
   });
 
   it('bar chart with splitField survives roundtrip', async () => {

--- a/server/src/integration-tests/suites/kibana-roundtrip.test.ts
+++ b/server/src/integration-tests/suites/kibana-roundtrip.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+/**
+ * Kibana roundtrip tests — export_to_kibana → import_from_kibana.
+ *
+ * These tests exercise the critical version-dependent code paths:
+ *   - Kibana <  9.4  →  saved objects API  (hasDashboardApi = false)
+ *   - Kibana >= 9.4  →  Dashboard API      (hasDashboardApi = true)
+ *
+ * The same tests run against both 9.3 and 9.4 via STACK_VERSION env var.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  SAMPLE_BAR_CHART_ARGS,
+  SAMPLE_LINE_CHART_ARGS,
+} from '../__fixtures__/dashboard-factory.js';
+import { expectSuccess, expectTextContent } from '../helpers/mcp-assertions.js';
+import { MCPTestServer } from '../setup/test-server.js';
+
+describe('Kibana roundtrip', () => {
+  let server: MCPTestServer;
+
+  beforeEach(async () => {
+    server = new MCPTestServer();
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('should export a dashboard with a single chart to Kibana', async () => {
+    await server.callTool('create_dashboard', { title: 'Export Test Single' });
+    await server.callTool('create_chart', SAMPLE_BAR_CHART_ARGS);
+
+    const result = await server.callTool('export_to_kibana');
+    const text = expectSuccess(result);
+    // Should contain a Kibana URL or dashboard ID
+    expect(text.toLowerCase()).toMatch(/dashboard|exported|kibana|created/);
+  });
+
+  it('should export a dashboard with multiple charts to Kibana', async () => {
+    await server.callTool('create_dashboard', { title: 'Export Test Multi' });
+    await server.callTool('create_chart', SAMPLE_BAR_CHART_ARGS);
+    await server.callTool('create_chart', SAMPLE_LINE_CHART_ARGS);
+
+    const result = await server.callTool('export_to_kibana');
+    const text = expectSuccess(result);
+    expect(text.toLowerCase()).toMatch(/dashboard|exported|kibana|created/);
+  });
+
+  it('should export with a title override', async () => {
+    await server.callTool('create_dashboard', { title: 'Original Title' });
+    await server.callTool('create_chart', SAMPLE_BAR_CHART_ARGS);
+
+    const result = await server.callTool('export_to_kibana', {
+      title: 'Overridden Title',
+    });
+    const text = expectSuccess(result);
+    expect(text.toLowerCase()).toMatch(/dashboard|exported|kibana|created/);
+  });
+
+  it('should fail to export an empty dashboard', async () => {
+    await server.callTool('create_dashboard', { title: 'Empty Dashboard' });
+
+    const result = await server.callTool('export_to_kibana');
+    const text = expectTextContent(result);
+    expect(result.isError).toBe(true);
+    expect(text.toLowerCase()).toContain('no charts');
+  });
+
+  it('should roundtrip: export then import preserves charts', async () => {
+    // Create and populate a dashboard
+    await server.callTool('create_dashboard', { title: 'Roundtrip Test' });
+    await server.callTool('create_chart', {
+      ...SAMPLE_BAR_CHART_ARGS,
+      id: 'roundtrip-bar',
+    });
+
+    // Export to Kibana
+    const exportResult = await server.callTool('export_to_kibana');
+    const exportText = expectSuccess(exportResult);
+
+    // Extract the dashboard ID from the URL in the export response
+    // URL format: http://localhost:55026/app/dashboards#/view/<id>
+    const urlMatch = exportText.match(/#\/view\/([^\s"'\n]+)/);
+
+    if (!urlMatch) {
+      // If we can't extract an ID, just verify the export succeeded
+      expect(exportText.toLowerCase()).toMatch(/dashboard|exported|kibana|created/);
+      return;
+    }
+
+    const kibanaDashboardId = urlMatch[1];
+
+    // Import from Kibana into a fresh dashboard
+    const importResult = await server.callTool('import_from_kibana', {
+      dashboardId: kibanaDashboardId,
+    });
+    const importText = expectSuccess(importResult);
+    expect(importText.toLowerCase()).toMatch(/import|dashboard|created/);
+  });
+});

--- a/server/src/integration-tests/suites/metric-heatmap.test.ts
+++ b/server/src/integration-tests/suites/metric-heatmap.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { SAMPLE_METRIC_ARGS, SAMPLE_HEATMAP_ARGS } from '../__fixtures__/dashboard-factory.js';
+import { expectSuccess, expectTextContent } from '../helpers/mcp-assertions.js';
+import { MCPTestServer } from '../setup/test-server.js';
+
+describe('Metric and heatmap tools', () => {
+  let server: MCPTestServer;
+
+  beforeEach(async () => {
+    server = new MCPTestServer();
+    await server.start();
+    await server.callTool('create_dashboard', { title: 'Metric Heatmap Test' });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  describe('create_metric', () => {
+    it('should create a metric visualization', async () => {
+      const result = await server.callTool('create_metric', SAMPLE_METRIC_ARGS);
+      const text = expectSuccess(result);
+      expect(text).toContain('Total Revenue');
+    });
+
+    it('should create a metric with subtitle and color', async () => {
+      const result = await server.callTool('create_metric', {
+        ...SAMPLE_METRIC_ARGS,
+        subtitle: 'Last 30 days',
+        color: '#E91E63',
+      });
+      const text = expectSuccess(result);
+      expect(text).toContain('Total Revenue');
+    });
+
+    it('should handle invalid ES|QL gracefully', async () => {
+      const result = await server.callTool('create_metric', {
+        ...SAMPLE_METRIC_ARGS,
+        esqlQuery: 'INVALID QUERY',
+      });
+      const text = expectTextContent(result);
+      expect(text.toLowerCase()).toMatch(/error|failed|invalid|parse/);
+    });
+  });
+
+  describe('create_heatmap', () => {
+    it('should create a heatmap visualization', async () => {
+      const result = await server.callTool('create_heatmap', SAMPLE_HEATMAP_ARGS);
+      const text = expectSuccess(result);
+      expect(text).toContain('Category by Gender');
+    });
+
+    it('should handle invalid ES|QL gracefully', async () => {
+      const result = await server.callTool('create_heatmap', {
+        ...SAMPLE_HEATMAP_ARGS,
+        esqlQuery: 'INVALID QUERY',
+      });
+      const text = expectTextContent(result);
+      expect(text.toLowerCase()).toMatch(/error|failed|invalid|parse/);
+    });
+  });
+});

--- a/server/src/integration-tests/suites/sections.test.ts
+++ b/server/src/integration-tests/suites/sections.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { SAMPLE_BAR_CHART_ARGS } from '../__fixtures__/dashboard-factory.js';
+import { expectSuccess } from '../helpers/mcp-assertions.js';
+import { MCPTestServer } from '../setup/test-server.js';
+
+describe('Section tools', () => {
+  let server: MCPTestServer;
+
+  beforeEach(async () => {
+    server = new MCPTestServer();
+    await server.start();
+    await server.callTool('create_dashboard', { title: 'Section Test' });
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('should create a section', async () => {
+    const result = await server.callTool('create_section', {
+      id: 'overview-section',
+      title: 'Overview',
+    });
+    const text = expectSuccess(result);
+    expect(text).toContain('Overview');
+  });
+
+  it('should move a panel into a section', async () => {
+    // Create a chart first
+    await server.callTool('create_chart', {
+      ...SAMPLE_BAR_CHART_ARGS,
+      id: 'revenue-chart',
+    });
+
+    // Create a section
+    await server.callTool('create_section', {
+      id: 'metrics-section',
+      title: 'Metrics',
+    });
+
+    // Move chart into section
+    const result = await server.callTool('move_panel_to_section', {
+      panelId: 'revenue-chart',
+      sectionId: 'metrics-section',
+    });
+    const text = expectSuccess(result);
+    expect(text).toContain('revenue-chart');
+    expect(text).toContain('metrics-section');
+  });
+
+  it('should create a section with initial panel IDs', async () => {
+    await server.callTool('create_chart', {
+      ...SAMPLE_BAR_CHART_ARGS,
+      id: 'chart-in-section',
+    });
+
+    const result = await server.callTool('create_section', {
+      id: 'pre-populated',
+      title: 'Pre-populated Section',
+      panelIds: ['chart-in-section'],
+    });
+    const text = expectSuccess(result);
+    expect(text).toContain('Pre-populated Section');
+  });
+
+  it('should remove a section', async () => {
+    await server.callTool('create_section', {
+      id: 'temp-section',
+      title: 'Temporary',
+    });
+
+    const result = await server.callTool('remove_section', {
+      sectionId: 'temp-section',
+    });
+    const text = expectSuccess(result);
+    expect(text.toLowerCase()).toContain('temp-section');
+  });
+});

--- a/server/src/integration-tests/suites/server-startup.test.ts
+++ b/server/src/integration-tests/suites/server-startup.test.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { expectToolsExist } from '../helpers/mcp-assertions.js';
+import { MCPTestServer } from '../setup/test-server.js';
+
+describe('Server startup', () => {
+  let server: MCPTestServer;
+
+  beforeEach(async () => {
+    server = new MCPTestServer();
+    await server.start();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  it('should register all expected tools', async () => {
+    const tools = await server.listTools();
+
+    expectToolsExist(tools, [
+      // ES|QL tools
+      'run_esql',
+      'list_indices',
+      // Dashboard management
+      'create_dashboard',
+      'list_dashboards',
+      'switch_dashboard',
+      'delete_dashboard',
+      'set_dashboard_title',
+      'clear_dashboard',
+      'remove_chart',
+      'view_dashboard',
+      // Visualization tools
+      'create_chart',
+      'create_metric',
+      'create_heatmap',
+      // Section tools
+      'create_section',
+      'move_panel_to_section',
+      'remove_section',
+      // Kibana integration
+      'export_to_kibana',
+      'import_from_kibana',
+    ]);
+  });
+
+  it('should register all expected resources', async () => {
+    const resources = await server.listResources();
+    const uris = resources.resources.map((r) => r.uri);
+
+    expect(uris).toContain('dataviz://guidelines');
+    expect(uris).toContain('esql://reference');
+  });
+
+  it('should return non-empty dataviz guidelines', async () => {
+    const result = await server.readResource('dataviz://guidelines');
+    const text = result.contents[0];
+    expect(text).toBeDefined();
+    expect(text.mimeType).toBe('text/markdown');
+    expect((text as { text: string }).text.length).toBeGreaterThan(100);
+  });
+
+  it('should return non-empty ES|QL reference', async () => {
+    const result = await server.readResource('esql://reference');
+    const text = result.contents[0];
+    expect(text).toBeDefined();
+    expect(text.mimeType).toBe('text/markdown');
+    expect((text as { text: string }).text.length).toBeGreaterThan(100);
+  });
+});

--- a/server/src/utils/dashboard-store.ts
+++ b/server/src/utils/dashboard-store.ts
@@ -17,7 +17,8 @@ import { resolve, basename } from 'path';
 import type { DashboardConfig, PanelConfig, SectionConfig } from '../types.js';
 import { PROJECT_ROOT } from './config.js';
 
-const DASHBOARDS_DIR = resolve(PROJECT_ROOT, 'preview', 'public', 'dashboards');
+const DASHBOARDS_DIR =
+  process.env.DASHBOARDS_DIR || resolve(PROJECT_ROOT, 'preview', 'public', 'dashboards');
 // Track which dashboard is active
 const ACTIVE_ID_PATH = resolve(DASHBOARDS_DIR, '.active');
 

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -10,6 +10,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
-    exclude: ['dist/**', 'node_modules/**'],
+    exclude: ['dist/**', 'node_modules/**', 'src/integration-tests/**'],
   },
 });

--- a/server/vitest.integration.config.ts
+++ b/server/vitest.integration.config.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License 2.0;
+ * you may not use this file except in compliance with the Elastic License 2.0.
+ */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'mcp-integration',
+    globals: true,
+    environment: 'node',
+    include: ['src/integration-tests/suites/**/*.test.ts'],
+    globalSetup: ['src/integration-tests/setup/global.ts'],
+    testTimeout: 30_000,
+    hookTimeout: 120_000, // ES + Kibana container startup
+    sequence: { concurrent: false },
+    reporters: ['verbose'],
+  },
+});


### PR DESCRIPTION
Closes #33.

Adds end-to-end integration tests for the MCP server using testcontainers (Elasticsearch + Kibana). Tests exercise the full MCP client → server → ES/Kibana roundtrip via `StdioClientTransport`.

The same 47 tests run against both **9.3.0** (saved objects API) and **9.4.0-SNAPSHOT** (Dashboard API), validating both code paths in `export_to_kibana` / `import_from_kibana`.

### Test suites

- **server-startup** — tool/resource registration
- **esql-tools** — `run_esql`, `list_indices` against real ES
- **chart-lifecycle** — create dashboard → create chart → view → remove
- **metric-heatmap** — `create_metric`, `create_heatmap`
- **sections** — `create_section`, `move_panel_to_section`, `remove_section`
- **dashboard-management** — list, rename, switch, delete, clear
- **kibana-roundtrip** — export → import preserves chart configs (type, query, fields, palette, splitField, subtitle, color), section order and panel assignments

### CI

Adds a matrix job to the CI workflow that runs integration tests against 9.3.0 and 9.4.0-SNAPSHOT in parallel.

CI output looks like this:

```
Run npx vitest run --config vitest.integration.config.ts
 RUN  v4.1.2 /home/runner/work/example-mcp-dashbuilder/example-mcp-dashbuilder/server
🐳 Starting Elasticsearch: docker.elastic.co/elasticsearch/elasticsearch:9.3.0
✅ Elasticsearch ready at http://localhost:32769
🌱 Seeding test_ecommerce index…
✅ Seeded 20 documents into test_ecommerce
🐳 Starting Kibana: docker.elastic.co/kibana/kibana:9.3.0
✅ Kibana ready at http://localhost:32770
 ✓  mcp-integration  src/integration-tests/suites/chart-lifecycle.test.ts > Chart lifecycle > should create a dashboard and return its ID 4115ms
 ✓  mcp-integration  src/integration-tests/suites/esql-tools.test.ts > ES|QL tools > list_indices > should return the seeded test index 3939ms
 ✓  mcp-integration  src/integration-tests/suites/chart-lifecycle.test.ts > Chart lifecycle > should create a bar chart on a dashboard 3292ms
.......
 ✓  mcp-integration  src/integration-tests/suites/metric-heatmap.test.ts > Metric and heatmap tools > create_heatmap > should handle invalid ES|QL gracefully 1547ms
 ✓  mcp-integration  src/integration-tests/suites/server-startup.test.ts > Server startup > should return non-empty dataviz guidelines 1393ms
 ✓  mcp-integration  src/integration-tests/suites/server-startup.test.ts > Server startup > should return non-empty ES|QL reference 1045ms
 Test Files  8 passed (8)
      Tests  47 passed (47)
   Start at  08:32:51
   Duration  90.85s (transform 509ms, setup 0ms, import 3.49s, tests 115.29s, environment 9ms)
🧹 Tearing down containers…
✅ Containers stopped
```

### Test isolation

Each `MCPTestServer` instance spawns a fresh server process with its own temp `DASHBOARDS_DIR` — tests never touch user dashboards or interfere with each other.

